### PR TITLE
Support multiple sessions in test server

### DIFF
--- a/netconf/example_test.go
+++ b/netconf/example_test.go
@@ -79,13 +79,14 @@ func ExampleSession_Subscribe() {
 
 	serverAddress := fmt.Sprintf("localhost:%d", ts.Port())
 	s, _ := NewRPCSession(context.Background(), sshConfig, serverAddress)
+	sh := ts.SessionHandler(s.ID())
 
 	nch := make(chan *Notification)
 	_, _ = s.Subscribe(Request(`<ncEvent:create-subscription xmlns:ncEvent="urn:ietf:params:xml:ns:netconf:notification:1.0"></ncEvent:create-subscription>`), nch)
 
 	// Get test server to send a notification in 500ms.
 	time.AfterFunc(time.Millisecond*time.Duration(500), func() {
-		ts.SendNotification(`<typeA xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-notifications"><name>XXX</name></typeA>`)
+		sh.SendNotification(`<typeA xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-notifications"><name>XXX</name></typeA>`)
 	})
 
 	n := <-nch

--- a/netconf/message.go
+++ b/netconf/message.go
@@ -38,7 +38,7 @@ type Session interface {
 	Close()
 
 	// ID delivers the server-allocated id of the session.
-	ID() int
+	ID() uint64
 }
 
 type sesImpl struct {
@@ -182,7 +182,7 @@ func (si *sesImpl) Close() {
 	}
 }
 
-func (si *sesImpl) ID() int {
+func (si *sesImpl) ID() uint64 {
 	return si.hello.SessionID
 }
 

--- a/netconf/message_test.go
+++ b/netconf/message_test.go
@@ -30,6 +30,7 @@ func TestNewSessionWithChunkedEncoding(t *testing.T) {
 func TestExecute(t *testing.T) {
 
 	ts := NewTestNetconfServer(t)
+	assert.Nil(t, ts.LastReq(), "No requests should have been executed")
 	ncs := newNCClientSession(t, ts)
 	defer ncs.Close()
 

--- a/netconf/message_test.go
+++ b/netconf/message_test.go
@@ -29,13 +29,17 @@ func TestNewSessionWithChunkedEncoding(t *testing.T) {
 
 func TestExecute(t *testing.T) {
 
-	ncs := newNCClientSession(t, NewTestNetconfServer(t))
+	ts := NewTestNetconfServer(t)
+	ncs := newNCClientSession(t, ts)
 	defer ncs.Close()
 
 	reply, err := ncs.Execute(Request(`<get><response/></get>`))
 	assert.NoError(t, err, "Not expecting exec to fail")
 	assert.NotNil(t, reply, "Reply should be non-nil")
 	assert.Equal(t, `<data><response/></data>`, reply.Data, "Reply should contain response data")
+	assert.Equal(t, 1, ts.ReqCount(), "Expected request count to be 1")
+	assert.Equal(t, "get", ts.LastReq().XMLName.Local, "Expected GET request")
+	assert.Equal(t, "<response/>", ts.LastReq().Body, "Expected request body")
 }
 
 func TestExecuteWithFailingRequest(t *testing.T) {
@@ -187,7 +191,7 @@ func TestConcurrentExecute(t *testing.T) {
 		}(r)
 	}
 	wg.Wait()
-	assert.Equal(t, 1000, ts.ReqCount, "Unexpected request count")
+	assert.Equal(t, 1000, ts.ReqCount(), "Unexpected request count")
 }
 
 func TestConcurrentExecuteAsync(t *testing.T) {
@@ -215,7 +219,7 @@ func TestConcurrentExecuteAsync(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.Equal(t, 1000, ts.ReqCount, "Unexpected request count")
+	assert.Equal(t, 1000, ts.ReqCount(), "Unexpected request count")
 }
 
 func BenchmarkExecute(b *testing.B) {

--- a/netconf/model.go
+++ b/netconf/model.go
@@ -14,7 +14,7 @@ type Request string
 type HelloMessage struct {
 	XMLName      xml.Name `xml:"urn:ietf:params:xml:ns:netconf:base:1.0 hello"`
 	Capabilities []string `xml:"capabilities>capability"`
-	SessionID    int      `xml:"session-id,omitempty"`
+	SessionID    uint64      `xml:"session-id,omitempty"`
 }
 
 // RPCMessage defines the an rpc request message

--- a/netconf/test_netconf_handler.go
+++ b/netconf/test_netconf_handler.go
@@ -54,7 +54,7 @@ type netconfSessionHandler struct {
 // rpcRequestMessage and rpcRequest represent an RPC request from a client, where the element type of the
 // request body is unknown.
 type rpcRequestMessage struct {
-	XMLName   xml.Name //`xml:"rpc"`
+	XMLName   xml.Name 
 	MessageID string     `xml:"message-id,attr"`
 	Request   RPCRequest `xml:",any"`
 }

--- a/netconf/test_netconf_server.go
+++ b/netconf/test_netconf_server.go
@@ -51,7 +51,7 @@ func NewTestNetconfServer(tctx assert.TestingT) *TestNCServer {
 func (ncs *TestNCServer) newFactory() testutil.HandlerFactory {
 	return func(t assert.TestingT) (testutil.SSHHandler) {
 		sid := atomic.AddUint64(&ncs.nextSid, 1)
-		sess := newSessionHandler(ncs, sid, ncs.reqLogger)
+		sess := newSessionHandler(ncs, sid)
 		ncs.sessionHandlers[sid] = sess
 		sess.capabilities = ncs.caps
 		sess.reqHandlers = ncs.reqHandlers
@@ -97,18 +97,6 @@ func (ncs *TestNCServer) Errorf(format string, args ...interface{}) {
 // created.
 func (ncs *TestNCServer) FailNow() {
 	runtime.Goexit()
-}
-
-func (ncs *TestNCServer) ReqCount() int {
-	return len(ncs.Reqs)
-}
-
-func (ncs *TestNCServer) LastReq() *RPCRequest {
-	count := len(ncs.Reqs)
-	if count > 0 {
-		return &ncs.Reqs[count-1]
-	}
-	return nil
 }
 
 // SessionHandler delivers the netconf session handler associated with the specified session id.

--- a/netconf/test_netconf_server.go
+++ b/netconf/test_netconf_server.go
@@ -21,7 +21,6 @@ const (
 type TestNCServer struct {
 	*testutil.SSHServer
 	sessionHandlers map[uint64]*NetconfSessionHandler
-	Reqs []RPCRequest
 	reqHandlers []RequestHandler
 	caps []string
 	nextSid uint64

--- a/netconf/test_netconf_server.go
+++ b/netconf/test_netconf_server.go
@@ -20,7 +20,7 @@ const (
 // be invoked to handle netconf messages.
 type TestNCServer struct {
 	*testutil.SSHServer
-	sessionHandlers map[uint64]*netconfSessionHandler
+	sessionHandlers map[uint64]*NetconfSessionHandler
 	Reqs []RPCRequest
 	reqHandlers []RequestHandler
 	caps []string
@@ -35,7 +35,7 @@ type TestNCServer struct {
 // WithRequestHandler methods.
 func NewTestNetconfServer(tctx assert.TestingT) *TestNCServer {
 
-	ncs := &TestNCServer{sessionHandlers: make(map[uint64]*netconfSessionHandler)}
+	ncs := &TestNCServer{sessionHandlers: make(map[uint64]*NetconfSessionHandler)}
 
 	if tctx == nil {
 		// Default test context to built-in implementation.
@@ -59,9 +59,8 @@ func (ncs *TestNCServer) newFactory() testutil.HandlerFactory {
 	}
 }
 
-func (ncs *TestNCServer) reqLogger(r RPCRequest)  {
-	// TODO SJ Make this goroutine-safe
-	ncs.Reqs = append(ncs.Reqs, r)
+func (ncs *TestNCServer) LastHandler() (*NetconfSessionHandler) {
+	return ncs.sessionHandlers[ncs.nextSid]
 }
 
 // WithRequestHandler adds a request handler to the netconf session.
@@ -100,7 +99,7 @@ func (ncs *TestNCServer) FailNow() {
 }
 
 // SessionHandler delivers the netconf session handler associated with the specified session id.
-func (ncs *TestNCServer) SessionHandler(id uint64) (*netconfSessionHandler) {
+func (ncs *TestNCServer) SessionHandler(id uint64) (*NetconfSessionHandler) {
 	sh, ok := ncs.sessionHandlers[id]
 	if !ok {
 		ncs.tctx.Errorf("Failed to get handler for session %d", id)

--- a/netconf/test_netconf_server_test.go
+++ b/netconf/test_netconf_server_test.go
@@ -1,0 +1,29 @@
+package netconf
+
+import (
+	assert "github.com/stretchr/testify/require"
+	"testing"
+)
+
+
+func TestMultipleSessions(t *testing.T) {
+
+	ts := NewTestNetconfServer(t)
+	assert.Nil(t, ts.LastReq(), "No requests should have been executed")
+
+	ncs := newNCClientSession(t, ts)
+
+	reply, err := ncs.Execute(Request(`<get><response/></get>`))
+	assert.NoError(t, err, "Not expecting exec to fail")
+	assert.NotNil(t, reply, "Reply should be non-nil")
+
+	ncs.Close()
+
+	ncs = newNCClientSession(t, ts)
+	defer ncs.Close()
+
+	reply, err = ncs.Execute(Request(`<get><response/></get>`))
+	assert.NoError(t, err, "Not expecting exec to fail")
+	assert.NotNil(t, reply, "Reply should be non-nil")
+
+}

--- a/netconf/test_netconf_server_test.go
+++ b/netconf/test_netconf_server_test.go
@@ -9,9 +9,9 @@ import (
 func TestMultipleSessions(t *testing.T) {
 
 	ts := NewTestNetconfServer(t)
-	assert.Nil(t, ts.LastReq(), "No requests should have been executed")
 
 	ncs := newNCClientSession(t, ts)
+	assert.Nil(t, ts.SessionHandler(ncs.ID()).LastReq(), "No requests should have been executed")
 
 	reply, err := ncs.Execute(Request(`<get><response/></get>`))
 	assert.NoError(t, err, "Not expecting exec to fail")

--- a/netconf/trace.go
+++ b/netconf/trace.go
@@ -47,7 +47,7 @@ type ClientTrace struct {
 
 	// ConnectionClosed is called after a transport connection has been closed, with
 	// err indicating any error condition.
-	ConnectionClosed func(err error)
+	ConnectionClosed func(target string, err error)
 
 	// ReadStart is called before a read from the underlying transport.
 	ReadStart func(buf []byte)
@@ -62,7 +62,7 @@ type ClientTrace struct {
 	WriteDone func(buf []byte, c int, err error, d time.Duration)
 
 	// Error is called after an error condition has been detected.
-	Error func(context string, err error)
+	Error func(context, target string, err error)
 
 	// NotificationReceived is called when a notification has been received.
 	NotificationReceived func(m *Notification)
@@ -79,8 +79,8 @@ type ClientTrace struct {
 
 // DefaultLoggingHooks provides a default logging hook to report errors.
 var DefaultLoggingHooks = &ClientTrace{
-	Error: func(context string, err error) {
-		log.Printf("Error context:%s err:%v\n", context, err)
+	Error: func(context, target string, err error) {
+		log.Printf("Error context:%s target:%s err:%v\n", context, target, err)
 	},
 }
 
@@ -92,8 +92,8 @@ var DiagnosticLoggingHooks = &ClientTrace{
 	ConnectDone: func(clientConfig *ssh.ClientConfig, target string, err error, d time.Duration) {
 		log.Printf("ConnectDone target:%s config:%v err:%v took:%dns\n", target, clientConfig, err, d)
 	},
-	ConnectionClosed: func(err error) {
-		log.Printf("ConnectionClosed err:%v\n", err)
+	ConnectionClosed: func(target string, err error) {
+		log.Printf("ConnectionClosed target:%s err:%v\n", target, err)
 	},
 	ReadStart: func(p []byte) {
 		log.Printf("ReadStart capacity:%d\n", len(p))
@@ -108,8 +108,8 @@ var DiagnosticLoggingHooks = &ClientTrace{
 		log.Printf("WriteDone len:%d err:%v took:%dns\n", c, err, d)
 	},
 
-	Error: func(context string, err error) {
-		log.Printf("Error context:%s err:%v\n", context, err)
+	Error: func(context, target string, err error) {
+		log.Printf("Error context:%s target:%s err:%v\n", context, target, err)
 	},
 	NotificationReceived: func(n *Notification) {
 		log.Printf("NotificationReceived %s\n", n.XMLName.Local)
@@ -129,7 +129,7 @@ var DiagnosticLoggingHooks = &ClientTrace{
 var NoOpLoggingHooks = &ClientTrace{
 	ConnectStart:     func(clientConfig *ssh.ClientConfig, target string) {},
 	ConnectDone:      func(clientConfig *ssh.ClientConfig, target string, err error, d time.Duration) {},
-	ConnectionClosed: func(err error) {},
+	ConnectionClosed: func(target string, err error) {},
 
 	ReadStart: func(p []byte) {},
 	ReadDone:  func(p []byte, c int, err error, d time.Duration) {},
@@ -137,7 +137,7 @@ var NoOpLoggingHooks = &ClientTrace{
 	WriteStart: func(p []byte) {},
 	WriteDone:  func(p []byte, c int, err error, d time.Duration) {},
 
-	Error:                func(context string, err error) {},
+	Error:                func(context, target string, err error) {},
 	NotificationReceived: func(n *Notification) {},
 	NotificationDropped:  func(n *Notification) {},
 	ExecuteStart:         func(req Request, async bool) {},

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -24,6 +24,7 @@ type tImpl struct {
 	sshSession  *ssh.Session
 	sshClient   *ssh.Client
 	trace       *ClientTrace
+	target 		string
 }
 
 // NewSSHTransport creates a new SSH transport, connecting to the target with the supplied client configuration
@@ -31,7 +32,7 @@ type tImpl struct {
 // nolint : gosec
 func NewSSHTransport(ctx context.Context, clientConfig *ssh.ClientConfig, target, subsystem string) (rt Transport, err error) {
 
-	var impl tImpl
+	impl := tImpl{target: target}
 	impl.trace = ContextClientTrace(ctx)
 
 	impl.trace.ConnectStart(clientConfig, target)
@@ -97,7 +98,7 @@ func (t *tImpl) Write(p []byte) (n int, err error) {
 // Errors are returned with priority matching the same order.
 func (t *tImpl) Close() (err error) {
 
-	defer t.trace.ConnectionClosed(err)
+	defer t.trace.ConnectionClosed(t.target, err)
 
 	var (
 		writeCloseErr      error

--- a/netconf/transport_test.go
+++ b/netconf/transport_test.go
@@ -88,8 +88,8 @@ func TestTrace(t *testing.T) {
 			traces = append(traces, fmt.Sprintf("ConnectDone %s error:%v", target, err))
 			assert.True(t, d > 0, "Duration should be defined")
 		},
-		ConnectionClosed: func(err error) {
-			traces = append(traces, fmt.Sprintf("ConnectionClosed error:%v", err))
+		ConnectionClosed: func(target string, err error) {
+			traces = append(traces, fmt.Sprintf("ConnectionClosed target:%s error:%v", target, err))
 		},
 		ReadStart: func(p []byte) {
 			traces = append(traces, "ReadStart called")
@@ -122,5 +122,5 @@ func TestTrace(t *testing.T) {
 	assert.Equal(t, "WriteDone Message\n 8 <nil>", traces[3])
 	assert.Equal(t, "ReadStart called", traces[4])
 	assert.Equal(t, "ReadDone GOT:Message\n 12 <nil>", traces[5])
-	assert.Equal(t, fmt.Sprintf("ConnectionClosed error:<nil>"), traces[6])
+	assert.Contains(t, traces[6], fmt.Sprintf("ConnectionClosed target:localhost:"), traces[6])
 }


### PR DESCRIPTION
Add support for multiple netconf sessions against a single test server.

Also, changes to provide more useful context to diagnostic hooks.