### PR TITLE
Feature/ut timeout

### DIFF
--- a/netconf/rfc6242/framer.go
+++ b/netconf/rfc6242/framer.go
@@ -88,7 +88,14 @@ func decoderEndOfMessage(d *Decoder, b []byte, atEOF bool) (advance int, token [
 				if d.pendingFramer != nil {
 					d.framer = d.pendingFramer
 					d.pendingFramer = nil
-					return
+					// If there is more input beyond the EOM, this must be processed with the new framer.
+					if advance < len(b) {
+						var adv int
+						adv, token, err = d.framer(d, b[advance:], atEOF)
+						if err == nil {
+							advance += adv
+						}
+					}
 				}
 				d.anySeen = true
 				if !atEOF {

--- a/netconf/test_netconf_handler.go
+++ b/netconf/test_netconf_handler.go
@@ -54,7 +54,7 @@ type netconfSessionHandler struct {
 // rpcRequestMessage and rpcRequest represent an RPC request from a client, where the element type of the
 // request body is unknown.
 type rpcRequestMessage struct {
-	XMLName   xml.Name //`xml:"rpc"`
+	XMLName   xml.Name 
 	MessageID string     `xml:"message-id,attr"`
 	Request   RPCRequest `xml:",any"`
 }


### PR DESCRIPTION
When transitioning to a new framer (i.e. typically when switching to a 1.1 chunking framer), after processing the EOM with the original framer, need to handle any additional available input with the new framer.

This led to intermittent 'hangs' after creating a new netconf session.

Highlights need to revisit this code (cloned from github.com/andaru/netconf) to tidy up and properly unit test.