### PR TITLE
Remove stretchr/testify contstraint.

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,11 +25,6 @@
 #   unused-packages = true
 
 
-
-[[constraint]]
-  name = "github.com/stretchr/testify"
-  version = "1.2.2"  
-
 [[constraint]]
   branch = "master"
   name = "golang.org/x/crypto"


### PR DESCRIPTION
Removing the explicit constraint allows projects that depend on this package to use alternative versions of stretchr/testify.