### PR TITLE
 Skeleton for implementation of SNMP manager

### DIFF
--- a/v2/netconf/server/netconf/trace_test.go
+++ b/v2/netconf/server/netconf/trace_test.go
@@ -15,3 +15,14 @@ func TestDefaultHooksForUntestableExceptions(t *testing.T) {
 	hooks.Decoded(session, errors.New("failed"))
 
 }
+
+func TestNoLoggingHooks(t *testing.T) {
+
+	hooks := NoOpLoggingHooks
+	session := &SessionHandler{}
+	hooks.ClientHello(session)
+	hooks.EndSession(session, errors.New("failed"))
+	hooks.Encoded(session, errors.New("failed"))
+	hooks.Decoded(session, errors.New("failed"))
+
+}

--- a/v2/snmp/manager.go
+++ b/v2/snmp/manager.go
@@ -1,0 +1,60 @@
+package snmp
+
+import (
+	"context"
+	"net"
+)
+
+// Manager provides an interface for SNMP device management.
+type Manager interface {
+	// Issues an SNMP GET request for the specified oids.
+	Get(ctx context.Context, oids []string) (*Response, error)
+
+	// Issues an SNMP GET NEXT request for the specified oids.
+	GetNext(ctx context.Context, oids []string) (*Response, error)
+
+	// Issues an SNMP GET BULK request for the specified oids.
+	GetBulk(ctx context.Context, oids []string, nonRepeaters int, maxRepetitions int) (*Response, error)
+
+	// Issues an SNMP GET BULK request starting from the specified oid, invoking the function walker for each PDU.
+	GetWalk(ctx context.Context, oid string, walker Walker) error
+}
+
+// Response defines the response to a Get... request.
+type Response struct {
+	// TBD
+}
+
+// Walker defines a function that will be called for each PDU processed by the GetWalk method.
+// If the function returns an error, the walk will be terminated.
+type Walker func(pdu *PDU) error
+
+// PDU defines ...
+type PDU struct {
+	// TBD
+}
+
+type managerImpl struct {
+	conn   net.Conn
+	config *managerConfig
+}
+
+func (m *managerImpl) Get(ctx context.Context, oids []string) (*Response, error) {
+	// TODO
+	return nil, nil
+}
+
+func (m *managerImpl) GetNext(ctx context.Context, oids []string) (*Response, error) {
+	// TODO
+	return nil, nil
+}
+
+func (m *managerImpl) GetBulk(ctx context.Context, oids []string, nonRepeaters int, maxRepetitions int) (*Response, error) {
+	// TODO
+	return nil, nil
+}
+
+func (m *managerImpl) GetWalk(ctx context.Context, oid string, walker Walker) error {
+	// TODO
+	return nil
+}

--- a/v2/snmp/manager_test.go
+++ b/v2/snmp/manager_test.go
@@ -1,0 +1,31 @@
+package snmp
+
+import (
+	"context"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestNoOpImplementations(t *testing.T) {
+	m, err := NewFactory().NewManager(context.Background(), "localhost:161")
+	assert.NoError(t, err)
+
+	r, err := m.Get(context.Background(), []string{"1.3.6.1.2.1.2.2.1.1"})
+	assert.Nil(t, r)
+	assert.Nil(t, err)
+
+	r, err = m.GetNext(context.Background(), []string{"1.3.6.1.2.1.2.2.1.1"})
+	assert.Nil(t, r)
+	assert.Nil(t, err)
+
+	r, err = m.GetBulk(context.Background(), []string{"1.3.6.1.2.1.2.2.1.1"}, 5, 10)
+	assert.Nil(t, r)
+	assert.Nil(t, err)
+
+	walker := func(p *PDU) error {
+		return nil
+	}
+	err = m.GetWalk(context.Background(), "1.3.6.1.2.1.2.2.1.1", walker)
+	assert.Nil(t, err)
+}

--- a/v2/snmp/managerfactory.go
+++ b/v2/snmp/managerfactory.go
@@ -1,0 +1,136 @@
+package snmp
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/imdario/mergo"
+)
+
+// Defines a factory method for instantiating SNMP Managers.
+type ManagerFactory interface {
+	// NewManager instantiates an SNMP manager for managing the target device.
+	NewManager(ctx context.Context, target string, opts ...ManagerOption) (Manager, error)
+}
+
+// Delivers a new manager factory.
+func NewFactory() ManagerFactory {
+	return &factoryImpl{}
+}
+
+type factoryImpl struct{}
+
+func (f *factoryImpl) NewManager(ctx context.Context, target string, opts ...ManagerOption) (Manager, error) {
+
+	config := defaultConfig
+	config.address = target
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	mergo.Merge(config.trace, NoOpLoggingHooks) // nolint: gosec, errcheck
+
+	conn, err := newConnection(ctx, &config)
+	if err != nil {
+		config.trace.Error("Network Connection", &config, err)
+		return nil, err
+	}
+	return &managerImpl{config: &config, conn: conn}, nil
+}
+
+// ManagerOption implements options for configuring manager behaviour.
+type ManagerOption func(*managerConfig)
+
+// Timeout defines the timeout for receiving a response to a request
+// Default value is 1s.
+func Timeout(timeout time.Duration) ManagerOption {
+	return func(c *managerConfig) {
+		c.timeout = timeout
+	}
+}
+
+// Retries defines the number of times an unsuccessful request will be retried.
+// Default value is 0
+func Retries(value int) ManagerOption {
+	return func(c *managerConfig) {
+		c.retries = value
+	}
+}
+
+// Network defines the transport network.
+// Default value is udp
+func Network(value string) ManagerOption {
+	return func(c *managerConfig) {
+		c.network = value
+	}
+}
+
+// Version defines the SNMP version to use.
+// Default value is SNMPV2C
+func Version(value SNMPVersion) ManagerOption {
+	return func(c *managerConfig) {
+		c.version = value
+	}
+}
+
+// Commmunity defines the community string to be used.
+// Default value is public.
+func Community(value string) ManagerOption {
+	return func(c *managerConfig) {
+		c.community = value
+	}
+}
+
+// LoggingHooks defines a set of logging hooks to be used by the manager.
+// Default value is DefaultLoggingHooks.
+func LoggingHooks(trace *ManagerTrace) ManagerOption {
+	return func(c *managerConfig) {
+		c.trace = trace
+	}
+}
+
+// SNMP Versions.
+type SNMPVersion int
+
+const (
+	SNMPV1 SNMPVersion = iota
+	SNMPV2C
+	SNMPV3
+)
+
+// Deliver a new network connection to the address defined in the configuration.
+func newConnection(ctx context.Context, m *managerConfig) (conn net.Conn, err error) {
+	m.trace.ConnectStart(m)
+	defer m.trace.ConnectDone(m, err)
+	return net.Dial(m.network, m.address)
+}
+
+// Defines properties controlling manager behaviour.
+type managerConfig struct {
+	// Connection network, typically udp.
+	network string
+	// Network address/hostname with port, for example: 10.48.24.234:161
+	address string
+	// SNMP version
+	version SNMPVersion
+	// community string for v2c.
+	community string
+	// Timeout for receiving a response
+	timeout time.Duration
+	// Defines the number of times an unsuccessful request will be retried.
+	retries int
+	// Trace hooks
+	trace *ManagerTrace
+	// TODO Define additional configuration properties as required.
+}
+
+var defaultConfig = managerConfig{
+	network:   "udp",
+	address:   "",
+	community: "public",
+	version:   SNMPV2C,
+	timeout:   time.Second,
+	retries:   0,
+	trace:     DefaultLoggingHooks,
+}

--- a/v2/snmp/managerfactory_test.go
+++ b/v2/snmp/managerfactory_test.go
@@ -1,0 +1,44 @@
+package snmp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestNewManagerSuccess(t *testing.T) {
+	f := NewFactory()
+	m, err := f.NewManager(context.Background(), "localhost:161")
+	assert.NoError(t, err)
+	assert.NotNil(t, m, "Session should not be nil")
+}
+
+func TestNewManagerOptions(t *testing.T) {
+	f := NewFactory()
+	m, err := f.NewManager(context.Background(), "localhost:161",
+		Network("udp"),
+		Timeout(time.Second),
+		Retries(5),
+		Version(SNMPV2C),
+		Community("public"),
+		LoggingHooks(DiagnosticLoggingHooks),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, m, "Session should not be nil")
+	impl := m.(*managerImpl)
+	assert.Equal(t, "localhost:161", impl.config.address)
+	assert.Equal(t, "udp", impl.config.network)
+	assert.Equal(t, time.Second, impl.config.timeout)
+	assert.Equal(t, 5, impl.config.retries)
+	assert.Equal(t, SNMPV2C, impl.config.version)
+	assert.Equal(t, "public", impl.config.community)
+}
+
+func TestConnectionFailure(t *testing.T) {
+	f := NewFactory()
+	m, err := f.NewManager(context.Background(), "localhost:0")
+	assert.Error(t, err, "Expecting new session to fail - invalid port")
+	assert.Nil(t, m, "Session should be nil")
+}

--- a/v2/snmp/managerfactory_test.go
+++ b/v2/snmp/managerfactory_test.go
@@ -38,7 +38,7 @@ func TestNewManagerOptions(t *testing.T) {
 
 func TestConnectionFailure(t *testing.T) {
 	f := NewFactory()
-	m, err := f.NewManager(context.Background(), "localhost:0")
+	m, err := f.NewManager(context.Background(), "nosuchhost:161")
 	assert.Error(t, err, "Expecting new session to fail - invalid port")
 	assert.Nil(t, m, "Session should be nil")
 }

--- a/v2/snmp/trace.go
+++ b/v2/snmp/trace.go
@@ -1,0 +1,47 @@
+package snmp
+
+import (
+	"log"
+)
+
+// ManagerTrace defines a structure for handling trace events
+type ManagerTrace struct {
+	// ConnectStart is called before establishing a network connection to an agent.
+	ConnectStart func(config *managerConfig)
+
+	// ConnectDone is called when the network connection attempt completes, with err indicating
+	// whether it was successful.
+	ConnectDone func(config *managerConfig, err error)
+
+	// Error is called after an error condition has been detected.
+	Error func(location string, config *managerConfig, err error)
+
+	// TODO Define other hooks
+}
+
+// DefaultLoggingHooks provides a default logging hook to report errors.
+var DefaultLoggingHooks = &ManagerTrace{
+	Error: func(location string, config *managerConfig, err error) {
+		log.Printf("Error context:%s target:%s err:%v\n", location, config.address, err)
+	},
+}
+
+// DiagnosticLoggingHooks provides a set of default diagnostic hooks
+var DiagnosticLoggingHooks = &ManagerTrace{
+	ConnectStart: func(config *managerConfig) {
+		log.Printf("ConnectStart target:%s\n", config.address)
+	},
+	ConnectDone: func(config *managerConfig, err error) {
+		log.Printf("ConnectDone target:%s err:%v\n", config.address, err)
+	},
+	Error: func(location string, config *managerConfig, err error) {
+		log.Printf("Error context:%s target:%s err:%v\n", location, config.address, err)
+	},
+}
+
+// NoOpLoggingHooks provides set of hooks that do nothing.
+var NoOpLoggingHooks = &ManagerTrace{
+	ConnectStart: func(config *managerConfig) {},
+	ConnectDone:  func(config *managerConfig, err error) {},
+	Error:        func(location string, config *managerConfig, err error) {},
+}

--- a/v2/snmp/trace_test.go
+++ b/v2/snmp/trace_test.go
@@ -1,0 +1,18 @@
+package snmp
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDiagnosticHooksForUntestableExceptions(t *testing.T) {
+
+	hooks := DiagnosticLoggingHooks
+	hooks.Error("Context", &managerConfig{}, errors.New("problem"))
+}
+
+func TestNoLoggingHooks(t *testing.T) {
+
+	hooks := NoOpLoggingHooks
+	hooks.Error("Context", &managerConfig{}, errors.New("problem"))
+}


### PR DESCRIPTION
Main item is the definition of the Manager interface (Get, GetNext etc).

Note:
- Have located snmp directory under the v2 folder, rather than at the top level.
- The interface methods define synchronous Gets (although the Walk variant allows a degree of asynchronousness); depending on implementation, may be able to expose asynchronous variants.
- Need to determine and define whether the implementation is concurrent-safe
