### PR TITLE
Clean up code using default linters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ git:
 
 before_script:
   - go get -u github.com/mattn/goveralls
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.21.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.26.0
 
 script:
   - ./bin/golangci-lint run
+  - (cd v2; ../bin/golangci-lint run)
   - (cd v2 ; go test -timeout 120s -race $(go list ./...| grep -v testserver) -coverprofile=coverage.out) # Run all the tests with the race detector enabled
   - (cd v2; goveralls -coverprofile=coverage.out -service travis-ci)

--- a/netconf/transport_test.go
+++ b/netconf/transport_test.go
@@ -122,5 +122,5 @@ func TestTrace(t *testing.T) {
 	assert.Equal(t, "WriteDone Message\n 8 <nil>", traces[3])
 	assert.Equal(t, "ReadStart called", traces[4])
 	assert.Equal(t, "ReadDone GOT:Message\n 12 <nil>", traces[5])
-	assert.Contains(t, traces[6], fmt.Sprintf("ConnectionClosed target:localhost:"), traces[6])
+	assert.Contains(t, traces[6], "ConnectionClosed target:localhost:", traces[6])
 }

--- a/v2/netconf/client/transport_test.go
+++ b/v2/netconf/client/transport_test.go
@@ -122,5 +122,5 @@ func TestTrace(t *testing.T) {
 	assert.Equal(t, "WriteDone Message\n 8 <nil>", traces[3])
 	assert.Equal(t, "ReadStart called", traces[4])
 	assert.Equal(t, "ReadDone GOT:Message\n 12 <nil>", traces[5])
-	assert.Contains(t, traces[6], fmt.Sprintf("ConnectionClosed target:localhost:"), traces[6])
+	assert.Contains(t, traces[6], "ConnectionClosed target:localhost:", traces[6])
 }

--- a/v2/netconf/common/model_test.go
+++ b/v2/netconf/common/model_test.go
@@ -1,13 +1,10 @@
 package common
 
 import (
-	assert "github.com/stretchr/testify/require"
 	"testing"
-)
 
-type testStr struct {
-	Field string
-}
+	assert "github.com/stretchr/testify/require"
+)
 
 func TestRPCErrorString(t *testing.T) {
 
@@ -19,8 +16,7 @@ func TestRPCErrorString(t *testing.T) {
 	assert.Equal(t, "netconf rpc [Severity] 'Message'", err.Error())
 }
 
-
 func TestPeerSupportsChunkedFraming(t *testing.T) {
-	assert.False(t, PeerSupportsChunkedFraming([]string {NetconfNS, NetconfNotifyNS, CapBase10}))
-	assert.True(t, PeerSupportsChunkedFraming([]string {NetconfNS, NetconfNotifyNS, CapBase11}))
+	assert.False(t, PeerSupportsChunkedFraming([]string{NetconfNS, NetconfNotifyNS, CapBase10}))
+	assert.True(t, PeerSupportsChunkedFraming([]string{NetconfNS, NetconfNotifyNS, CapBase11}))
 }

--- a/v2/netconf/ops/example_test.go
+++ b/v2/netconf/ops/example_test.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func ExampleSession_GetSubTreeUsingStrings() {
+func ExampleOpSession_GetSubtree_usingStrings() {
 
 	ts := testserver.NewTestNetconfServer(nil).WithRequestHandler(testserver.SmartRequesttHandler)
 
@@ -39,7 +39,7 @@ func ExampleSession_GetSubTreeUsingStrings() {
 	// Output: <top><sub attr="avalue"><child1>cvalue</child1><child2/></sub></top>
 }
 
-func ExampleSession_GetSubTreeUsingStructs() {
+func ExampleOpSession_GetSubtree_usingStructs() {
 
 	ts := testserver.NewTestNetconfServer(nil).WithRequestHandler(testserver.SmartRequesttHandler)
 
@@ -57,7 +57,7 @@ func ExampleSession_GetSubTreeUsingStructs() {
 
 	type testSub struct {
 		XMLName xml.Name `xml:"sub"`
-		Attr    string   `xml:"attr,attr""`
+		Attr    string   `xml:"attr,attr"`
 		Child1  string   `xml:"child1"`
 		Child2  string   `xml:"child2"`
 	}
@@ -83,7 +83,7 @@ func ExampleSession_GetSubTreeUsingStructs() {
 	// cvalue
 }
 
-func ExampleSession_GetXpath() {
+func ExampleOpSession_GetXpath() {
 
 	ts := testserver.NewTestNetconfServer(nil).WithRequestHandler(testserver.SmartRequesttHandler)
 
@@ -112,7 +112,7 @@ func ExampleSession_GetXpath() {
 	// Output: <top><sub attr="avalue"><child1>cvalue</child1><child2/></sub></top>
 }
 
-func ExampleSession_GetConfig() {
+func ExampleOpSession_GetConfigSubtree() {
 
 	ts := testserver.NewTestNetconfServer(nil).WithRequestHandler(testserver.SmartRequesttHandler)
 
@@ -130,7 +130,7 @@ func ExampleSession_GetConfig() {
 
 	type testSub struct {
 		XMLName xml.Name `xml:"sub"`
-		Attr    string   `xml:"attr,attr""`
+		Attr    string   `xml:"attr,attr"`
 		Child1  string   `xml:"child1"`
 		Child2  string   `xml:"child2"`
 	}
@@ -156,7 +156,7 @@ func ExampleSession_GetConfig() {
 	// cfgval2
 }
 
-func ExampleSession_GetSchema() {
+func ExampleOpSession_GetSchema() {
 
 	ts := testserver.NewTestNetconfServer(nil).WithRequestHandler(testserver.SmartRequesttHandler)
 

--- a/v2/netconf/ops/model.go
+++ b/v2/netconf/ops/model.go
@@ -28,7 +28,7 @@ const (
 
 type Data struct {
 	XMLName xml.Name    `xml:"data"`
-	Body    interface{} `xml:",any""`
+	Body    interface{} `xml:",any"`
 	Content string      `xml:",innerxml"`
 }
 
@@ -41,7 +41,7 @@ type Schema struct {
 }
 
 type NetconfState struct {
-	XMLName xml.Name `xml:"urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring netconf-state`
+	XMLName xml.Name `xml:"urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring netconf-state"`
 	Xmlns   string   `xml:"xmlns,attr"`
 	Schemas struct {
 		Schema []Schema `xml:"schema"`

--- a/v2/netconf/ops/session.go
+++ b/v2/netconf/ops/session.go
@@ -366,7 +366,7 @@ type GetReq struct {
 
 type ConfigType struct {
 	Type string `xml:",innerxml"`
-	Url  string `xml:"url,omitempty""`
+	Url  string `xml:"url,omitempty"`
 }
 
 type GetConfigReq struct {

--- a/v2/netconf/ops/sessionfactory.go
+++ b/v2/netconf/ops/sessionfactory.go
@@ -29,7 +29,3 @@ func NewSessionWithConfig(ctx context.Context, sshcfg *ssh.ClientConfig, target 
 	s = &sImpl{Session: cs}
 	return
 }
-
-func createTransport(ctx context.Context, clientConfig *ssh.ClientConfig, target string) (t client.Transport, err error) {
-	return client.NewSSHTransport(ctx, clientConfig, target, "netconf")
-}

--- a/v2/netconf/server/netconf/example_test.go
+++ b/v2/netconf/server/netconf/example_test.go
@@ -28,7 +28,7 @@ func (es *exampleServer) HandleRequest(req *RpcRequestMessage) *RpcReplyMessage 
 	return nil
 }
 
-func Example_NewServer() {
+func ExampleNewServer() {
 
 	sshcfg, _ := ssh.PasswordConfig("UserA", "PassA")
 	server, _ := NewServer(context.Background(), "localhost", 0, sshcfg,

--- a/v2/netconf/server/ssh/server_test.go
+++ b/v2/netconf/server/ssh/server_test.go
@@ -22,8 +22,8 @@ type sHandler struct{}
 
 func (s *sHandler) Handle(ch xssh.Channel) {
 	buffer := make([]byte, 5)
-	ch.Read(buffer)
-	ch.Write([]byte(">" + string(buffer) + "<"))
+	_, _ = ch.Read(buffer)
+	_, _ = ch.Write([]byte(">" + string(buffer) + "<"))
 }
 
 func handlerFactory() HandlerFactory {
@@ -56,9 +56,9 @@ func TestServer(t *testing.T) {
 	assert.NoError(t, err, "Not expecting new transport to fail")
 	defer tr.Close()
 
-	tr.Write([]byte("hello"))
+	_, _ = tr.Write([]byte("hello"))
 	buffer := make([]byte, 7)
-	tr.Read(buffer)
+	_, _ = tr.Read(buffer)
 	assert.Equal(t, ">hello<", string(buffer))
 }
 
@@ -123,9 +123,9 @@ func TestServerDiagnosticTraceHooks(t *testing.T) {
 	assert.NoError(t, err, "Not expecting new transport to fail")
 	defer tr.Close()
 
-	tr.Write([]byte("hello"))
+	_, _ = tr.Write([]byte("hello"))
 	buffer := make([]byte, 7)
-	tr.Read(buffer)
+	_, _ = tr.Read(buffer)
 	assert.Equal(t, ">hello<", string(buffer))
 }
 
@@ -153,8 +153,8 @@ func TestServerNoOpTraceHooks(t *testing.T) {
 	assert.NoError(t, err, "Not expecting new transport to fail")
 	defer tr.Close()
 
-	tr.Write([]byte("hello"))
+	_, _ = tr.Write([]byte("hello"))
 	buffer := make([]byte, 7)
-	tr.Read(buffer)
+	_, _ = tr.Read(buffer)
 	assert.Equal(t, ">hello<", string(buffer))
 }


### PR DESCRIPTION
Ensure lint is run on v2.

Use linter version 1.26.0.