### PR TITLE
Hooks

### DIFF
--- a/v2/netconf/client/rpcsessionfactory_test.go
+++ b/v2/netconf/client/rpcsessionfactory_test.go
@@ -66,6 +66,12 @@ func TestSessionWithHooks(t *testing.T) {
 	assert.NotContains(t, logged, "ConnectStart", "ConnectStart should not be logged")
 	assert.NotContains(t, logged, "ReadDone", "ReadDone should not be logged")
 
+	logged = exerciseSession(t, MetricLoggingHooks)
+	assert.NotEqual(t, "", logged, "Something should be logged")
+	assert.Contains(t, logged, "Error context", "Error should be logged")
+	assert.NotContains(t, logged, "ConnectStart", "ConnectStart should not be logged")
+	assert.Contains(t, logged, "ReadDone", "ReadDone should not be logged")
+
 	logged = exerciseSession(t, DiagnosticLoggingHooks)
 	assert.NotEqual(t, "", logged, "Something should be logged")
 	assert.Contains(t, logged, "Error context", "Error should be logged")

--- a/v2/netconf/client/trace.go
+++ b/v2/netconf/client/trace.go
@@ -85,51 +85,60 @@ type ClientTrace struct {
 // DefaultLoggingHooks provides a default logging hook to report errors.
 var DefaultLoggingHooks = &ClientTrace{
 	Error: func(context, target string, err error) {
-		log.Printf("Error context:%s target:%s err:%v\n", context, target, err)
+		log.Printf("NETCONF-Error context:%s target:%s err:%v\n", context, target, err)
+	},
+}
+
+// MetricLoggingHooks provides a set of hooks that will log network metrics.
+var MetricLoggingHooks = &ClientTrace{
+	ConnectDone: func(clientConfig *ssh.ClientConfig, target string, err error, d time.Duration) {
+		log.Printf("NETCONF-ConnectDone target:%s config:%v err:%v took:%dms\n", target, clientConfig, err, d.Milliseconds())
+	},
+	ReadDone: func(p []byte, c int, err error, d time.Duration) {
+		log.Printf("NETCONF-ReadDone len:%d err:%v took:%dms\n", c, err, d.Milliseconds())
+	},
+	WriteDone: func(p []byte, c int, err error, d time.Duration) {
+		log.Printf("NETCONF-WriteDone len:%d err:%v took:%dms\n", c, err, d.Milliseconds())
+	},
+
+	Error: DefaultLoggingHooks.Error,
+
+	ExecuteDone: func(req common.Request, async bool, res *common.RPCReply, err error, d time.Duration) {
+		log.Printf("NETCONF-ExecuteDone async:%v err:%v took:%dms\n", async, err, d.Milliseconds())
 	},
 }
 
 // DiagnosticLoggingHooks provides a set of default diagnostic hooks
 var DiagnosticLoggingHooks = &ClientTrace{
 	ConnectStart: func(clientConfig *ssh.ClientConfig, target string) {
-		log.Printf("ConnectStart target:%s config:%v\n", target, clientConfig)
+		log.Printf("NETCONF-ConnectStart target:%s config:%v\n", target, clientConfig)
 	},
-	ConnectDone: func(clientConfig *ssh.ClientConfig, target string, err error, d time.Duration) {
-		log.Printf("ConnectDone target:%s config:%v err:%v took:%dns\n", target, clientConfig, err, d)
-	},
+	ConnectDone: MetricLoggingHooks.ConnectDone,
 	ConnectionClosed: func(target string, err error) {
-		log.Printf("ConnectionClosed target:%s err:%v\n", target, err)
-	},
-	HelloDone: func(msg *common.HelloMessage) {
-		log.Printf("HelloDone hello:%v\n", msg)
+		log.Printf("NETCONF-ConnectionClosed target:%s err:%v\n", target, err)
 	},
 	ReadStart: func(p []byte) {
-		log.Printf("ReadStart capacity:%d\n", len(p))
+		log.Printf("NETCONF-ReadStart capacity:%d\n", len(p))
 	},
-	ReadDone: func(p []byte, c int, err error, d time.Duration) {
-		log.Printf("ReadDone len:%d err:%v took:%dns\n", c, err, d)
-	},
+	ReadDone: MetricLoggingHooks.ReadDone,
 	WriteStart: func(p []byte) {
-		log.Printf("WriteStart len:%d\n", len(p))
+		log.Printf("NETCONF-WriteStart len:%d\n", len(p))
 	},
-	WriteDone: func(p []byte, c int, err error, d time.Duration) {
-		log.Printf("WriteDone len:%d err:%v took:%dns\n", c, err, d)
-	},
+	WriteDone: MetricLoggingHooks.WriteDone,
 
-	Error: func(context, target string, err error) {
-		log.Printf("Error context:%s target:%s err:%v\n", context, target, err)
-	},
+	Error: DefaultLoggingHooks.Error,
+
 	NotificationReceived: func(n *common.Notification) {
-		log.Printf("NotificationReceived %s\n", n.XMLName.Local)
+		log.Printf("NETCONF-NotificationReceived %s\n", n.XMLName.Local)
 	},
 	NotificationDropped: func(n *common.Notification) {
-		log.Printf("NotificationDropped %s\n", n.XMLName.Local)
+		log.Printf("NETCONF-NotificationDropped %s\n", n.XMLName.Local)
 	},
 	ExecuteStart: func(req common.Request, async bool) {
-		log.Printf("ExecuteStart async:%v req:%s\n", async, req)
+		log.Printf("NETCONF-ExecuteStart async:%v req:%s\n", async, req)
 	},
 	ExecuteDone: func(req common.Request, async bool, res *common.RPCReply, err error, d time.Duration) {
-		log.Printf("ExecuteDone async:%v req:%s err:%v took:%dns\n", async, req, err, d)
+		log.Printf("NETCONF-ExecuteDone async:%v req:%s err:%v took:%dms\n", async, req, err, d.Milliseconds())
 	},
 }
 

--- a/v2/snmp/server_test.go
+++ b/v2/snmp/server_test.go
@@ -121,10 +121,10 @@ func TestInformAcknwoledgementFailure(t *testing.T) {
 
 	// Shoehorn a Done() of the WaitGroup into the WriteComplete hook.
 	// This mean we wait until the incoming inform message has been acknowledged.
-	hooks := *DiagnosticServerHooks
+	hooks := *DefaultServerHooks
 	config.trace = &hooks
 	config.trace.WriteComplete = func(config *serverConfig, addr net.Addr, output []byte, err error) {
-		DiagnosticServerHooks.WriteComplete(config, addr, output, err)
+		DefaultServerHooks.WriteComplete(config, addr, output, err)
 		h.wg.Done()
 	}
 	config.resolveServerHooks()

--- a/v2/snmp/server_test.go
+++ b/v2/snmp/server_test.go
@@ -67,11 +67,21 @@ func TestHandleInform(t *testing.T) {
 		}).MaxTimes(1)
 	mockConn.EXPECT().Close().Return(nil)
 
-	config := defaultServerConfig
-	config.trace = DiagnosticServerHooks
-	config.resolveServerHooks()
 	h := newHandler()
-	h.wg.Add(1)
+	h.wg.Add(2)
+
+	config := defaultServerConfig
+
+	// Shoehorn a Done() of the WaitGroup into the WriteComplete hook.
+	// This mean we wait until the incoming inform message has been acknowledged.
+	hooks := *DiagnosticServerHooks
+	config.trace = &hooks
+	config.trace.WriteComplete = func(config *serverConfig, addr net.Addr, output []byte, err error) {
+		DiagnosticServerHooks.WriteComplete(config, addr, output, err)
+		h.wg.Done()
+	}
+	config.resolveServerHooks()
+
 	s := &serverImpl{config: &config, conn: mockConn, handler: h}
 	defer s.Close()
 
@@ -81,6 +91,7 @@ func TestHandleInform(t *testing.T) {
 	assert.NotZero(t, h.pdu.VarbindList[0].TypedValue.Value, "upTime should be defined")
 	assert.Equal(t, "1.3.6.1.1.2.3", h.pdu.VarbindList[1].TypedValue.String())
 	assert.Equal(t, "123456", h.pdu.VarbindList[2].TypedValue.String())
+
 }
 
 func TestInformAcknwoledgementFailure(t *testing.T) {
@@ -103,11 +114,21 @@ func TestInformAcknwoledgementFailure(t *testing.T) {
 		}).MaxTimes(1)
 	mockConn.EXPECT().Close().Return(nil)
 
-	config := defaultServerConfig
-	config.trace = DefaultServerHooks
-	config.resolveServerHooks()
 	h := newHandler()
-	h.wg.Add(1)
+	h.wg.Add(2)
+
+	config := defaultServerConfig
+
+	// Shoehorn a Done() of the WaitGroup into the WriteComplete hook.
+	// This mean we wait until the incoming inform message has been acknowledged.
+	hooks := *DiagnosticServerHooks
+	config.trace = &hooks
+	config.trace.WriteComplete = func(config *serverConfig, addr net.Addr, output []byte, err error) {
+		DiagnosticServerHooks.WriteComplete(config, addr, output, err)
+		h.wg.Done()
+	}
+	config.resolveServerHooks()
+
 	s := &serverImpl{config: &config, conn: mockConn, handler: h}
 	defer s.Close()
 

--- a/v2/snmp/serverhooks.go
+++ b/v2/snmp/serverhooks.go
@@ -18,10 +18,10 @@ type ServerHooks struct {
 	// Error is called after an error condition has been detected.
 	Error func(config *serverConfig, err error)
 
-	// WriteDone is called after a packet has been written
+	// WriteComplete is called after a packet has been written
 	WriteComplete func(config *serverConfig, addr net.Addr, output []byte, err error)
 
-	// ReadDone is called after a read has completed
+	// ReadComplete is called after a read has completed
 	ReadComplete func(config *serverConfig, addr net.Addr, input []byte, err error)
 }
 
@@ -32,12 +32,12 @@ var DefaultServerHooks = &ServerHooks{
 	},
 	WriteComplete: func(config *serverConfig, addr net.Addr, output []byte, err error) {
 		if err != nil {
-			log.Printf("WriteDone target:%s err:%v\n", addr, err)
+			log.Printf("WriteComplete target:%s err:%v\n", addr, err)
 		}
 	},
 	ReadComplete: func(config *serverConfig, addr net.Addr, input []byte, err error) {
 		if err != nil {
-			log.Printf("ReadDone source:%s err:%v\n", addr, err)
+			log.Printf("ReadComplete source:%s err:%v\n", addr, err)
 		}
 	},
 }
@@ -54,10 +54,10 @@ var DiagnosticServerHooks = &ServerHooks{
 		log.Printf("Error err:%v\n", err)
 	},
 	WriteComplete: func(config *serverConfig, addr net.Addr, output []byte, err error) {
-		log.Printf("WriteDone target:%s err:%v data:%s\n", addr, err, hex.EncodeToString(output))
+		log.Printf("WriteComplete target:%s err:%v data:%s\n", addr, err, hex.EncodeToString(output))
 	},
 	ReadComplete: func(config *serverConfig, addr net.Addr, input []byte, err error) {
-		log.Printf("ReadDone source:%s err:%v data:%s\n", addr, err, hex.EncodeToString(input))
+		log.Printf("ReadComplete source:%s err:%v data:%s\n", addr, err, hex.EncodeToString(input))
 	},
 }
 

--- a/v2/snmp/serverhooks.go
+++ b/v2/snmp/serverhooks.go
@@ -18,10 +18,10 @@ type ServerHooks struct {
 	// Error is called after an error condition has been detected.
 	Error func(config *serverConfig, err error)
 
-	// WriteComplete is called after a packet has been written
+	// WriteDone is called after a packet has been written
 	WriteComplete func(config *serverConfig, addr net.Addr, output []byte, err error)
 
-	// ReadComplete is called after a read has completed
+	// ReadDone is called after a read has completed
 	ReadComplete func(config *serverConfig, addr net.Addr, input []byte, err error)
 }
 
@@ -32,12 +32,12 @@ var DefaultServerHooks = &ServerHooks{
 	},
 	WriteComplete: func(config *serverConfig, addr net.Addr, output []byte, err error) {
 		if err != nil {
-			log.Printf("WriteComplete target:%s err:%v\n", addr, err)
+			log.Printf("WriteDone target:%s err:%v\n", addr, err)
 		}
 	},
 	ReadComplete: func(config *serverConfig, addr net.Addr, input []byte, err error) {
 		if err != nil {
-			log.Printf("ReadComplete source:%s err:%v\n", addr, err)
+			log.Printf("ReadDone source:%s err:%v\n", addr, err)
 		}
 	},
 }
@@ -54,10 +54,10 @@ var DiagnosticServerHooks = &ServerHooks{
 		log.Printf("Error err:%v\n", err)
 	},
 	WriteComplete: func(config *serverConfig, addr net.Addr, output []byte, err error) {
-		log.Printf("WriteComplete target:%s err:%v data:%s\n", addr, err, hex.EncodeToString(output))
+		log.Printf("WriteDone target:%s err:%v data:%s\n", addr, err, hex.EncodeToString(output))
 	},
 	ReadComplete: func(config *serverConfig, addr net.Addr, input []byte, err error) {
-		log.Printf("ReadComplete source:%s err:%v data:%s\n", addr, err, hex.EncodeToString(input))
+		log.Printf("ReadDone source:%s err:%v data:%s\n", addr, err, hex.EncodeToString(input))
 	},
 }
 

--- a/v2/snmp/session.go
+++ b/v2/snmp/session.go
@@ -61,7 +61,7 @@ type Varbind struct {
 
 type sessionImpl struct {
 	conn          net.Conn
-	config        *sessionConfig
+	config        *SessionConfig
 	nextRequestID int32
 }
 

--- a/v2/snmp/session.go
+++ b/v2/snmp/session.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/geoffgarside/ber"
 )
@@ -199,16 +200,22 @@ func isOidDescendantOfRoot(oid asn1.ObjectIdentifier, rootOid string) bool {
 }
 
 func (m *sessionImpl) writePacket(b []byte) (err error) {
-	n, err := m.conn.Write(b)
-	m.config.trace.WriteComplete(m.config, b[0:n], err)
+	var n int
+	defer func(begin time.Time) {
+		m.config.trace.WriteDone(m.config, b[0:n], err, time.Since(begin))
+	}(time.Now())
+	n, err = m.conn.Write(b)
 	return
 }
 
 func (m *sessionImpl) readResponse() (input []byte, err error) {
 	input = make([]byte, maxInputBufferSize)
+	var n int
+	defer func(begin time.Time) {
+		m.config.trace.ReadDone(m.config, input[0:n], err, time.Since(begin))
+	}(time.Now())
 
-	n, err := m.conn.Read(input[:])
-	defer m.config.trace.ReadComplete(m.config, input[0:n], err)
+	n, err = m.conn.Read(input[:])
 	if err != nil {
 		return nil, err
 	}

--- a/v2/snmp/session_test.go
+++ b/v2/snmp/session_test.go
@@ -753,7 +753,7 @@ func TestBulkWalk(t *testing.T) {
 	config := defaultConfig
 	config.address = "localhost:161"
 	config.community = "public"
-	config.trace = DiagnosticLoggingHooks
+	config.trace = MetricLoggingHooks
 	m := &sessionImpl{config: &config, conn: mockConn, nextRequestID: 1}
 
 	varbinds := []*Varbind{}

--- a/v2/snmp/sessionfactory.go
+++ b/v2/snmp/sessionfactory.go
@@ -42,12 +42,12 @@ func (f *factoryImpl) NewSession(ctx context.Context, target string, opts ...Ses
 }
 
 // SessionOption implements options for configuring session behaviour.
-type SessionOption func(*sessionConfig)
+type SessionOption func(*SessionConfig)
 
 // Timeout defines the timeout for receiving a response to a request
 // Default value is 1s.
 func Timeout(timeout time.Duration) SessionOption {
-	return func(c *sessionConfig) {
+	return func(c *SessionConfig) {
 		c.timeout = timeout
 	}
 }
@@ -55,7 +55,7 @@ func Timeout(timeout time.Duration) SessionOption {
 // Retries defines the number of times an unsuccessful request will be retried.
 // Default value is 0
 func Retries(value int) SessionOption {
-	return func(c *sessionConfig) {
+	return func(c *SessionConfig) {
 		c.retries = value
 	}
 }
@@ -63,7 +63,7 @@ func Retries(value int) SessionOption {
 // Network defines the transport network.
 // Default value is udp
 func Network(value string) SessionOption {
-	return func(c *sessionConfig) {
+	return func(c *SessionConfig) {
 		c.network = value
 	}
 }
@@ -71,7 +71,7 @@ func Network(value string) SessionOption {
 // Version defines the SNMP version to use.
 // Default value is SNMPV2C
 func Version(value SNMPVersion) SessionOption {
-	return func(c *sessionConfig) {
+	return func(c *SessionConfig) {
 		c.version = value
 	}
 }
@@ -79,7 +79,7 @@ func Version(value SNMPVersion) SessionOption {
 // Commmunity defines the community string to be used.
 // Default value is public.
 func Community(value string) SessionOption {
-	return func(c *sessionConfig) {
+	return func(c *SessionConfig) {
 		c.community = value
 	}
 }
@@ -87,7 +87,7 @@ func Community(value string) SessionOption {
 // LoggingHooks defines a set of logging hooks to be used by the session.
 // Default value is DefaultLoggingHooks.
 func LoggingHooks(trace *SessionTrace) SessionOption {
-	return func(c *sessionConfig) {
+	return func(c *SessionConfig) {
 		c.trace = trace
 	}
 }
@@ -102,14 +102,14 @@ const (
 )
 
 // Deliver a new network connection to the address defined in the configuration.
-func newConnection(ctx context.Context, m *sessionConfig) (conn net.Conn, err error) {
+func newConnection(ctx context.Context, m *SessionConfig) (conn net.Conn, err error) {
 	m.trace.ConnectStart(m)
 	defer m.trace.ConnectDone(m, err)
 	return net.Dial(m.network, m.address)
 }
 
-// Defines properties controlling session behaviour.
-type sessionConfig struct {
+// SessionConfig defines properties controlling session behaviour.
+type SessionConfig struct {
 	// Connection network, typically udp.
 	network string
 	// Network address/hostname with port, for example: 10.48.24.234:161
@@ -127,7 +127,7 @@ type sessionConfig struct {
 	// TODO Define additional configuration properties as required.
 }
 
-var defaultConfig = sessionConfig{
+var defaultConfig = SessionConfig{
 	network:   "udp",
 	address:   "",
 	community: "public",

--- a/v2/snmp/sessionfactory.go
+++ b/v2/snmp/sessionfactory.go
@@ -102,10 +102,12 @@ const (
 )
 
 // Deliver a new network connection to the address defined in the configuration.
-func newConnection(ctx context.Context, m *SessionConfig) (conn net.Conn, err error) {
-	m.trace.ConnectStart(m)
-	defer m.trace.ConnectDone(m, err)
-	return net.Dial(m.network, m.address)
+func newConnection(ctx context.Context, c *SessionConfig) (conn net.Conn, err error) {
+	defer func(begin time.Time) {
+		c.trace.ConnectDone(c, err, time.Since(begin))
+	}(time.Now())
+	c.trace.ConnectStart(c)
+	return net.Dial(c.network, c.address)
 }
 
 // SessionConfig defines properties controlling session behaviour.

--- a/v2/snmp/trace.go
+++ b/v2/snmp/trace.go
@@ -30,36 +30,36 @@ type SessionTrace struct {
 // DefaultLoggingHooks provides a default logging hook to report errors.
 var DefaultLoggingHooks = &SessionTrace{
 	Error: func(location string, config *SessionConfig, err error) {
-		log.Printf("Error context:%s target:%s err:%v\n", location, config.address, err)
+		log.Printf("SNMP-Error context:%s target:%s err:%v\n", location, config.address, err)
 	},
 }
 
 // MetricLoggingHooks provides a set of hooks that log metrics.
 var MetricLoggingHooks = &SessionTrace{
 	ConnectDone: func(config *SessionConfig, err error, d time.Duration) {
-		log.Printf("ConnectDone target:%s err:%v took:%dms\n", config.address, err, d.Milliseconds())
+		log.Printf("SNMP-ConnectDone target:%s err:%v took:%dms\n", config.address, err, d.Milliseconds())
 	},
 	Error: DefaultLoggingHooks.Error,
 	WriteDone: func(config *SessionConfig, output []byte, err error, d time.Duration) {
-		log.Printf("WriteDone target:%s err:%v took:%dms\n", config.address, err, d.Milliseconds())
+		log.Printf("SNMP-WriteDone target:%s err:%v took:%dms\n", config.address, err, d.Milliseconds())
 	},
 	ReadDone: func(config *SessionConfig, input []byte, err error, d time.Duration) {
-		log.Printf("ReadDone target:%s err:%v took:%dms\n", config.address, err, d.Milliseconds())
+		log.Printf("SNMP-ReadDone target:%s err:%v took:%dms\n", config.address, err, d.Milliseconds())
 	},
 }
 
 // DiagnosticLoggingHooks provides a set of hooks that log all events with all data.
 var DiagnosticLoggingHooks = &SessionTrace{
 	ConnectStart: func(config *SessionConfig) {
-		log.Printf("ConnectStart target:%s\n", config.address)
+		log.Printf("SNMP-ConnectStart target:%s\n", config.address)
 	},
 	ConnectDone: MetricLoggingHooks.ConnectDone,
 	Error:       DefaultLoggingHooks.Error,
 	WriteDone: func(config *SessionConfig, output []byte, err error, d time.Duration) {
-		log.Printf("WriteDone target:%s err:%v took:%dms data:%s\n", config.address, err, d.Milliseconds(), hex.EncodeToString(output))
+		log.Printf("SNMP-WriteDone target:%s err:%v took:%dms data:%s\n", config.address, err, d.Milliseconds(), hex.EncodeToString(output))
 	},
 	ReadDone: func(config *SessionConfig, input []byte, err error, d time.Duration) {
-		log.Printf("ReadDone target:%s err:%v took:%dms data:%s\n", config.address, err, d.Milliseconds(), hex.EncodeToString(input))
+		log.Printf("SNMP-ReadDone target:%s err:%v took:%dms data:%s\n", config.address, err, d.Milliseconds(), hex.EncodeToString(input))
 	},
 }
 

--- a/v2/snmp/trace.go
+++ b/v2/snmp/trace.go
@@ -8,55 +8,55 @@ import (
 // SessionTrace defines a structure for handling trace events
 type SessionTrace struct {
 	// ConnectStart is called before establishing a network connection to an agent.
-	ConnectStart func(config *sessionConfig)
+	ConnectStart func(config *SessionConfig)
 
 	// ConnectDone is called when the network connection attempt completes, with err indicating
 	// whether it was successful.
-	ConnectDone func(config *sessionConfig, err error)
+	ConnectDone func(config *SessionConfig, err error)
 
 	// Error is called after an error condition has been detected.
-	Error func(location string, config *sessionConfig, err error)
+	Error func(location string, config *SessionConfig, err error)
 
 	// WriteComplete is called after a packet has been written
-	WriteComplete func(config *sessionConfig, output []byte, err error)
+	WriteComplete func(config *SessionConfig, output []byte, err error)
 
 	// ReadComplete is called after a read has completed
-	ReadComplete func(config *sessionConfig, input []byte, err error)
+	ReadComplete func(config *SessionConfig, input []byte, err error)
 
 	// TODO Define other hooks
 }
 
 // DefaultLoggingHooks provides a default logging hook to report errors.
 var DefaultLoggingHooks = &SessionTrace{
-	Error: func(location string, config *sessionConfig, err error) {
+	Error: func(location string, config *SessionConfig, err error) {
 		log.Printf("Error context:%s target:%s err:%v\n", location, config.address, err)
 	},
 }
 
 // DiagnosticLoggingHooks provides a set of default diagnostic hooks
 var DiagnosticLoggingHooks = &SessionTrace{
-	ConnectStart: func(config *sessionConfig) {
+	ConnectStart: func(config *SessionConfig) {
 		log.Printf("ConnectStart target:%s\n", config.address)
 	},
-	ConnectDone: func(config *sessionConfig, err error) {
+	ConnectDone: func(config *SessionConfig, err error) {
 		log.Printf("ConnectDone target:%s err:%v\n", config.address, err)
 	},
-	Error: func(location string, config *sessionConfig, err error) {
+	Error: func(location string, config *SessionConfig, err error) {
 		log.Printf("Error context:%s target:%s err:%v\n", location, config.address, err)
 	},
-	WriteComplete: func(config *sessionConfig, output []byte, err error) {
+	WriteComplete: func(config *SessionConfig, output []byte, err error) {
 		log.Printf("WriteComplete target:%s err:%v data:%s\n", config.address, err, hex.EncodeToString(output))
 	},
-	ReadComplete: func(config *sessionConfig, input []byte, err error) {
+	ReadComplete: func(config *SessionConfig, input []byte, err error) {
 		log.Printf("ReadComplete target:%s err:%v data:%s\n", config.address, err, hex.EncodeToString(input))
 	},
 }
 
 // NoOpLoggingHooks provides set of hooks that do nothing.
 var NoOpLoggingHooks = &SessionTrace{
-	ConnectStart:  func(config *sessionConfig) {},
-	ConnectDone:   func(config *sessionConfig, err error) {},
-	Error:         func(location string, config *sessionConfig, err error) {},
-	WriteComplete: func(config *sessionConfig, output []byte, err error) {},
-	ReadComplete:  func(config *sessionConfig, input []byte, err error) {},
+	ConnectStart:  func(config *SessionConfig) {},
+	ConnectDone:   func(config *SessionConfig, err error) {},
+	Error:         func(location string, config *SessionConfig, err error) {},
+	WriteComplete: func(config *SessionConfig, output []byte, err error) {},
+	ReadComplete:  func(config *SessionConfig, input []byte, err error) {},
 }

--- a/v2/snmp/trace_test.go
+++ b/v2/snmp/trace_test.go
@@ -8,11 +8,11 @@ import (
 func TestDiagnosticHooksForUntestableExceptions(t *testing.T) {
 
 	hooks := DiagnosticLoggingHooks
-	hooks.Error("Context", &sessionConfig{}, errors.New("problem"))
+	hooks.Error("Context", &SessionConfig{}, errors.New("problem"))
 }
 
 func TestNoLoggingHooks(t *testing.T) {
 
 	hooks := NoOpLoggingHooks
-	hooks.Error("Context", &sessionConfig{}, errors.New("problem"))
+	hooks.Error("Context", &SessionConfig{}, errors.New("problem"))
 }


### PR DESCRIPTION
Update hooks in line with recommendations from KMcP.

- Introduce MetricLoggingHooks, that just record time to complete nettwork operations.
- Rename SNMP ReadComplete/WriteComplete hooks to ReadDone/WriteDone, for consistency with netconf hooks.
- Pass duration to SNMP ReadDone/WriteDone hooks
- Export SNMP SessionConfig to allow user-defined hooks.