### PR TITLE
Undo previous change that dropped namespace from hello message 

### DIFF
--- a/v2/netconf/common/model.go
+++ b/v2/netconf/common/model.go
@@ -13,7 +13,7 @@ type Request interface{}
 // HelloMessage defines the message sent/received during session negotiation.
 // nolint: govet
 type HelloMessage struct {
-	XMLName      xml.Name `xml:" hello"` // space required before hello in XMLName tag
+	XMLName      xml.Name `xml:"urn:ietf:params:xml:ns:netconf:base:1.0 hello"`
 	Capabilities []string `xml:"capabilities>capability"`
 	SessionID    uint64   `xml:"session-id,omitempty"`
 }


### PR DESCRIPTION
Breaks access to cisco devices that are otherwise accessible.