### PR TITLE
Initial implementation of ssh cli client.

### DIFF
--- a/netconf/rfc6242/decoder.go
+++ b/netconf/rfc6242/decoder.go
@@ -93,7 +93,7 @@ func (d *Decoder) Read(b []byte) (n int, err error) {
 		d.pipedCount = len(token)
 		go func() {
 			if _, err = d.pw.Write(token); err != nil {
-				d.pr.CloseWithError(err) //nolint:gosec
+				_ = d.pr.CloseWithError(err)
 			}
 		}()
 		n, err = d.pr.Read(b)

--- a/netconf/rfc6242/decoder_test.go
+++ b/netconf/rfc6242/decoder_test.go
@@ -1,3 +1,4 @@
+//nolint: dupl
 package rfc6242
 
 import (
@@ -78,6 +79,7 @@ func TestEOMDecoding(t *testing.T) {
 		},
 	}
 
+	//nolint: scopelint
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			transport := newTransport()
@@ -132,6 +134,7 @@ func TestFramerTransition(t *testing.T) {
 		},
 	}
 
+	//nolint: scopelint
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			transport := newTransport()
@@ -140,7 +143,6 @@ func TestFramerTransition(t *testing.T) {
 
 			buffer := make([]byte, tt.buflen)
 			for i, resp := range tt.responses {
-
 				transport.Write(resp.inputs, i == len(tt.responses)-1)
 
 				count, err := d.Read(buffer)
@@ -159,6 +161,7 @@ func TestFramerTransition(t *testing.T) {
 	}
 }
 
+//nolint: funlen
 func TestChunkedFramer(t *testing.T) {
 	type decresp struct {
 		inputs     []string
@@ -250,6 +253,7 @@ func TestChunkedFramer(t *testing.T) {
 		},
 	}
 
+	//nolint: scopelint
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			transport := newTransport()
@@ -258,7 +262,6 @@ func TestChunkedFramer(t *testing.T) {
 
 			buffer := make([]byte, tt.buflen)
 			for i, resp := range tt.responses {
-
 				transport.Write(resp.inputs, i == len(tt.responses)-1)
 
 				count, err := d.Read(buffer)

--- a/netconf/rfc6242/encoder_test.go
+++ b/netconf/rfc6242/encoder_test.go
@@ -18,6 +18,7 @@ func TestEOMEncoding(t *testing.T) {
 		{"EmptyMessage", []string{""}, false, ""},
 	}
 
+	//nolint: scopelint
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := bytes.NewBuffer([]byte{})
@@ -53,6 +54,7 @@ func TestChunkedEncoding(t *testing.T) {
 		{"ChunkedMessage", 5, []string{"ABCDEFGH"}, true, "\n#5\n" + "ABCDE" + "\n#3\n" + "FGH" + "\n##\n"},
 	}
 
+	//nolint: scopelint
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := bytes.NewBuffer([]byte{})

--- a/netconf/rfc6242/framer.go
+++ b/netconf/rfc6242/framer.go
@@ -11,7 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-
+//nolint: gomnd
 package rfc6242
 
 import (
@@ -43,7 +43,6 @@ var tokenEOM = []byte("]]>]]>")
 
 // decoderEndOfMessage is the NETCONF 1.0 end-of-message delimited
 // decoding function.
-// nolint: gocyclo
 func decoderEndOfMessage(d *Decoder, b []byte, atEOF bool) (advance int, token []byte, err error) {
 	d.eofOK = false
 	var i int
@@ -101,11 +100,11 @@ func decoderEndOfMessage(d *Decoder, b []byte, atEOF bool) (advance int, token [
 			}
 		}
 	}
-	return
+	return advance, token, err
 }
 
 // decoderChunked is the NETCONF 1.1 chunked framing decoder function.
-// nolint : gocyclo
+//nolint: gocyclo
 func decoderChunked(d *Decoder, b []byte, atEOF bool) (advance int, token []byte, err error) {
 	if d.scanErr != nil {
 		err = d.scanErr
@@ -171,7 +170,7 @@ func decoderChunked(d *Decoder, b []byte, atEOF bool) (advance int, token []byte
 		}
 	}
 
-	return
+	return advance, token, err
 }
 
 type chunkHeaderAction int
@@ -244,11 +243,11 @@ func detectChunkHeader(b []byte) (action chunkHeaderAction, advance int, chunksi
 		if len(b) > 8 {
 			got = b[:8]
 		} else {
-			got = b[:]
+			got = b
 		}
 		err = chunkHeaderLexError{got: got, want: []byte("\n#")}
 	}
-	return
+	return action, advance, chunksize, err
 }
 
 type chunkHeaderLexError struct{ got, want, wexplicit []byte }

--- a/netconf/rpcsessionfactory.go
+++ b/netconf/rpcsessionfactory.go
@@ -23,7 +23,7 @@ func NewRPCSessionWithConfig(ctx context.Context, sshcfg *ssh.ClientConfig, targ
 	}
 
 	if s, err = NewSession(ctx, t, cfg); err != nil {
-		t.Close() //nolint:errcheck
+		_ = t.Close()
 	}
 	return
 }

--- a/netconf/test_netconf_handler.go
+++ b/netconf/test_netconf_handler.go
@@ -116,7 +116,7 @@ var FailingRequestHandler = func(h *SessionHandler, req *rpcRequestMessage) {
 
 // CloseRequestHandler closes the transport channel on request receipt.
 var CloseRequestHandler = func(h *SessionHandler, req *rpcRequestMessage) {
-	h.ch.Close() //nolint:gosec
+	_ = h.ch.Close()
 }
 
 // IgnoreRequestHandler does in nothing on receipt of a request.
@@ -173,7 +173,7 @@ func (h *SessionHandler) SendNotification(body string) *SessionHandler {
 
 // Close initiates session tear-down by closing the underlying transport channel.
 func (h *SessionHandler) Close() {
-	h.ch.Close() //nolint:gosec
+	_ = h.ch.Close()
 }
 
 func (h *SessionHandler) waitForClientHello() {

--- a/netconf/test_netconf_server.go
+++ b/netconf/test_netconf_server.go
@@ -78,7 +78,7 @@ func (ncs *TestNCServer) WithCapabilities(caps []string) *TestNCServer {
 func (ncs *TestNCServer) Close() {
 	for k, v := range ncs.sessionHandlers {
 		if v.ch != nil {
-			v.Close() //nolint:errcheck
+			v.Close()
 			ncs.sessionHandlers[k] = nil
 		}
 	}

--- a/netconf/test_netconf_server_test.go
+++ b/netconf/test_netconf_server_test.go
@@ -1,3 +1,4 @@
+//nolint: dupl
 package netconf
 
 import (

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -29,7 +29,6 @@ type tImpl struct {
 
 // NewSSHTransport creates a new SSH transport, connecting to the target with the supplied client configuration
 // and requesting the specified subsystem.
-// nolint : gosec
 func NewSSHTransport(ctx context.Context, clientConfig *ssh.ClientConfig, target, subsystem string) (rt Transport, err error) {
 	impl := tImpl{target: target}
 	impl.trace = ContextClientTrace(ctx)
@@ -41,13 +40,12 @@ func NewSSHTransport(ctx context.Context, clientConfig *ssh.ClientConfig, target
 	}(time.Now())
 
 	defer func() {
-		//nolint:errcheck
 		if err != nil {
 			if impl.sshClient != nil {
-				impl.sshClient.Close()
+				_ = impl.sshClient.Close()
 			}
 			if impl.sshSession != nil {
-				impl.sshSession.Close()
+				_ = impl.sshSession.Close()
 			}
 		}
 	}()
@@ -77,7 +75,7 @@ func NewSSHTransport(ctx context.Context, clientConfig *ssh.ClientConfig, target
 	impl.injectTraceWriter()
 
 	rt = &impl
-	return
+	return rt, err
 }
 
 func (t *tImpl) Read(p []byte) (n int, err error) {

--- a/testutil/test_server.go
+++ b/testutil/test_server.go
@@ -55,7 +55,6 @@ func (ts *SSHServer) Close() {
 }
 
 func acceptConnections(t assert.TestingT, listener net.Listener, config *ssh.ServerConfig, factory HandlerFactory) {
-	//nolint:errcheck
 	for {
 		nConn, err := listener.Accept()
 		if err != nil {

--- a/v2/ssh_cli/session.go
+++ b/v2/ssh_cli/session.go
@@ -1,0 +1,235 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/imdario/mergo"
+)
+
+// Session defines the API exposed by an SSH client.
+type Session interface {
+	// Send writes the supplied value to the server and returns the response.
+	// The behaviour can be modified by opts - see SendOption variants below.
+	Send(value string, opts ...SendOption) (string, error)
+	io.Closer
+}
+
+// SendOption implements options for configuring Send behaviour.
+type SendOption func(*SendConfig)
+
+// WaitFor defines the string that indicates the end of the response to the send.
+// Defaults to the current prompt.
+func WaitFor(sentinel string) SendOption {
+	return func(c *SendConfig) {
+		c.responseSentinel = sentinel
+	}
+}
+
+// NoNewline suppresses the newline that is by default appended to the Send string.
+func NoNewline() SendOption {
+	return func(c *SendConfig) {
+		c.suppressNewline = true
+	}
+}
+
+// ResetPrompt resets the current session prompt to the last unterminated line of response.
+func ResetPrompt() SendOption {
+	return func(c *SendConfig) {
+		c.resetPrompt = true
+	}
+}
+
+// NoWait indicates the Send should not wait for a response.
+func NoWait() SendOption {
+	return func(c *SendConfig) {
+		c.noResponse = true
+	}
+}
+
+// SendConfig defines properties controlling Send behaviour.
+type SendConfig struct {
+	suppressNewline  bool
+	resetPrompt      bool
+	noResponse       bool
+	responseSentinel string
+}
+
+type SessionImpl struct {
+	cfg   *SessionConfig
+	tport SSHTransport
+	// promptPattern defines the regex used to determine the end of a response.
+	promptPattern *regexp.Regexp
+	// Used to queue the inputs received from the server.
+	inputs chan []byte
+}
+
+// NewCliSession establishes a client connection to a cli session running on the server associated with the supplied
+// transport.
+func NewCliSession(ctx context.Context, tport SSHTransport, cfg *SessionConfig) (s *SessionImpl, err error) {
+	// Use supplied config, but apply any defaults to unspecified values.
+	resolvedConfig := *cfg
+	_ = mergo.Merge(&resolvedConfig, DefaultConfig)
+
+	// If caller has specified a specific prompt pattern, check it's valid.
+	var pattern *regexp.Regexp
+	if resolvedConfig.pattern != "" {
+		pattern, err = regexp.Compile(resolvedConfig.pattern)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid prompt pattern")
+		}
+	}
+
+	sess := &SessionImpl{cfg: &resolvedConfig, tport: tport, inputs: make(chan []byte), promptPattern: pattern}
+
+	// Launch the reader to capture input from the server.
+	sess.launchReader()
+
+	// Capture the cli prompt from the new session.
+	if resolvedConfig.autoDetect {
+		err = sess.capturePrompt()
+	} else if pattern != nil {
+		// Swallow the prompt value provided by the user.
+		_, err = sess.readUntilValue(pattern)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to capture cli prompt")
+	}
+
+	// Execute any initial commands, ignoring any response values.
+	for _, cmd := range sess.cfg.initCmds {
+		_, err = sess.Send(cmd)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to execute initial command "+cmd)
+		}
+	}
+
+	return sess, nil
+}
+
+// Captures the cli prompt.
+// We keep reading until a read times out.
+// Then we use the content after the last newline.
+func (s *SessionImpl) capturePrompt() error {
+	b, err := s.readUntilTimeout()
+	if err != nil {
+		return err
+	}
+	pbytes := b[bytes.LastIndex(b, []byte("\n"))+1:]
+	s.promptPattern = regexp.MustCompile(regexp.QuoteMeta(string(pbytes)))
+	return nil
+}
+
+// Keep reading input from the server, until a read times out.
+func (s *SessionImpl) readUntilTimeout() ([]byte, error) {
+	output := new(bytes.Buffer)
+	for {
+		select {
+		case rd := <-s.inputs:
+			if rd == nil {
+				return nil, io.EOF
+			}
+			_, _ = output.Write(rd)
+		case <-time.After(s.cfg.readTimeout):
+			return output.Bytes(), nil
+		}
+	}
+}
+
+func (s *SessionImpl) Send(output string, opts ...SendOption) (string, error) {
+	config := &SendConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// If a response is expected, check that a prompt has been defined or the WaitFor option has been specified.
+	if !config.noResponse && s.promptPattern == nil && config.responseSentinel == "" {
+		return "", fmt.Errorf("need to specify WaitFor if cli prompt is not defined")
+	}
+
+	// If the caller has specified a "WaitFor" value - check it's a valid regex.
+	var sentinel *regexp.Regexp
+	var err error
+	if config.responseSentinel != "" {
+		sentinel, err = regexp.Compile(config.responseSentinel)
+		if err != nil {
+			return "", errors.Wrap(err, "invalid WaitFor value")
+		}
+	}
+
+	// Write any output to the server.
+	if len(output) > 0 {
+		if !config.suppressNewline {
+			output += "\n"
+		}
+		_, err = s.tport.Write([]byte(output))
+		if err != nil {
+			return "", errors.Wrap(err, "failed to send command")
+		}
+	}
+
+	// Capture the response, unless none is expected.
+	if config.noResponse {
+		return "", nil
+	}
+
+	// If the output is expected to change the prompt value, capture the new prompt.
+	if config.resetPrompt {
+		return "", s.capturePrompt()
+	}
+
+	// Capture any input up to but not including the prompt.
+	if sentinel == nil {
+		sentinel = s.promptPattern
+	}
+	return s.readUntilValue(sentinel)
+}
+
+func (s *SessionImpl) Close() error {
+	return s.tport.Close()
+}
+
+// readUntilValue reads until the specified regex is found and returns the read data.
+func (s *SessionImpl) readUntilValue(sentinel *regexp.Regexp) (string, error) {
+	output := new(bytes.Buffer)
+	for {
+		b := <-s.inputs
+		if b == nil {
+			return "", io.EOF
+		}
+
+		output.Write(b)
+		tempSlice := bytes.ReplaceAll(output.Bytes(), []byte("\r\n"), []byte("\n"))
+		tempSlice = bytes.ReplaceAll(tempSlice, []byte("\r"), []byte("\n"))
+		lastNl := bytes.LastIndex(tempSlice, []byte("\n"))
+		lastLine := tempSlice
+		if lastNl >= 0 {
+			lastLine = tempSlice[lastNl+1:]
+		} else {
+			lastNl = 0
+		}
+		if sentinel.Match(lastLine) {
+			return string(tempSlice[0:lastNl]), nil
+		}
+	}
+}
+
+func (s *SessionImpl) launchReader() {
+	go func() {
+		defer close(s.inputs)
+		for {
+			stdoutBuf := make([]byte, 10000)
+			byteCount, err := s.tport.Read(stdoutBuf)
+			if err != nil {
+				return
+			}
+			s.inputs <- stdoutBuf[:byteCount]
+		}
+	}()
+}

--- a/v2/ssh_cli/session_test.go
+++ b/v2/ssh_cli/session_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestSessionSendDefault(t *testing.T) {
+	_, ts := dummyServer(t)
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(), fmt.Sprintf("localhost:%d", ts.Port()))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+
+	resp, err := session.Send("Command")
+	assert.NoError(t, err)
+	assert.Equal(t, "GOT:Command\n", resp)
+}
+
+func TestSessionSendAndWait(t *testing.T) {
+	_, ts := dummyServer(t)
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(), fmt.Sprintf("localhost:%d", ts.Port()))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+
+	resp, err := session.Send("Command")
+	assert.NoError(t, err)
+	assert.Equal(t, "GOT:Command\n", resp)
+
+	resp, err = session.Send("enable", WaitFor("Password: $"))
+	assert.NoError(t, err)
+	assert.Empty(t, resp)
+
+	resp, err = session.Send("EPASS", ResetPrompt())
+	assert.NoError(t, err)
+	assert.Empty(t, resp)
+
+	resp, err = session.Send("Command2")
+	assert.NoError(t, err)
+	assert.Equal(t, "GOT:Command2\n", resp)
+
+	resp, err = session.Send("enable", WaitFor("BadRegex)"))
+	assert.Contains(t, err.Error(), "invalid WaitFor value")
+	assert.Empty(t, resp)
+}
+
+func TestSessionSendOptions(t *testing.T) {
+	_, ts := dummyServer(t)
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(), fmt.Sprintf("localhost:%d", ts.Port()))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+
+	resp, err := session.Send("enable", WaitFor("Password: "))
+	assert.NoError(t, err)
+	assert.Empty(t, resp)
+
+	resp, err = session.Send("EPASS", ResetPrompt())
+	assert.NoError(t, err)
+	assert.Empty(t, resp)
+
+	_, err = session.Send("Command ", NoNewline(), NoWait())
+	assert.NoError(t, err)
+	resp, err = session.Send("Param")
+	assert.NoError(t, err)
+	assert.Equal(t, "GOT:Command Param\n", resp)
+}
+
+func TestSessionWithNoPrompt(t *testing.T) {
+	_, ts := dummyServerWithPrompt(t, "Special> ")
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(),
+		fmt.Sprintf("localhost:%d", ts.Port()),
+		WithPrompt(""))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+
+	// Lose the initial prompt.
+	_, err = session.Send("", WaitFor("Special> "))
+	assert.NoError(t, err)
+
+	resp, err := session.Send("command")
+	assert.Contains(t, err.Error(), "need to specify WaitFor")
+	assert.Empty(t, resp)
+
+	resp, err = session.Send("command", WaitFor("Special> "))
+	assert.NoError(t, err)
+	assert.Equal(t, "GOT:command\n", resp)
+}
+
+func TestSessionWithPrompt(t *testing.T) {
+	_, ts := dummyServer(t)
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(),
+		fmt.Sprintf("localhost:%d", ts.Port()),
+		WithPrompt("A.C> $"))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+
+	resp, err := session.Send("command")
+	assert.NoError(t, err)
+	assert.Equal(t, "GOT:command\n", resp)
+}

--- a/v2/ssh_cli/sessionfactory.go
+++ b/v2/ssh_cli/sessionfactory.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type SessionFactory interface {
+	NewSession(ctx context.Context, sshcfg *ssh.ClientConfig, target string, opts ...SessionOption) (s Session, err error)
+}
+
+// SessionOption implements options for configuring session behaviour.
+type SessionOption func(*SessionConfig)
+
+// WithCommand defines initialisation commands to be executed after a session has been established.
+func WithCommands(cmds ...string) SessionOption {
+	return func(c *SessionConfig) {
+		c.initCmds = cmds
+	}
+}
+
+// WithPrompt overrides the automatic prompt detection that a new client session applies to determine the cli prompt
+// that is used to detect the end of a server response.
+// A non-empty pattern value defines a regular expression that will be used to detect the cli prompt.
+// An empty pattern indicates the the WaitFor option when calling Send.
+func WithPrompt(pattern string) SessionOption {
+	return func(c *SessionConfig) {
+		c.autoDetect = false
+		c.pattern = pattern
+	}
+}
+
+// WithTimeout defines the length of time to wait without receiving any input that is used to determine
+// that the server has completed a response.
+// Typically, only used when auto-detecting the cli prompt.
+func WithTimeout(timeout time.Duration) SessionOption {
+	return func(c *SessionConfig) {
+		c.readTimeout = timeout
+	}
+}
+
+// SessionConfig defines properties controlling session behaviour.
+type SessionConfig struct {
+	// Any commands that should be executed after establishing a new session.
+	initCmds []string
+	// If true, the session will auto-detect the cli prompt at session startup.
+	autoDetect bool
+	// If not empty, defines a regular expression that should be used to identify the cli prompt.
+	// If pattern is empty and autoDetect is false, all calls to the Send() method should specfiy the WaitFor option.
+	pattern string
+	// See WithTimeout above.
+	readTimeout time.Duration
+}
+
+var DefaultConfig = SessionConfig{
+	autoDetect:  true,
+	readTimeout: time.Second * 1,
+}
+
+type FactoryImpl struct {
+	cfg *SessionConfig
+}
+
+func (f FactoryImpl) NewSession(ctx context.Context, sshcfg *ssh.ClientConfig, target string,
+	opts ...SessionOption) (s Session, err error) {
+	config := *f.cfg
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	t, err := NewSSHTransport(ctx, sshcfg, &TransportConfig{}, target)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCliSession(ctx, t, &config)
+}
+
+func NewSessionFactory(cfg *SessionConfig) SessionFactory {
+	if cfg == nil {
+		cfg = &DefaultConfig
+	}
+	return &FactoryImpl{cfg: cfg}
+}

--- a/v2/ssh_cli/sessionfactory_test.go
+++ b/v2/ssh_cli/sessionfactory_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/damianoneill/net/v2/netconf/testserver"
+
+	assert "github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestSessionWithFailingShell(t *testing.T) {
+	_, ts := dummyServerWithFailingShell(t)
+	defer ts.Close()
+
+	sshConfig := validSSHConfig()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), sshConfig,
+		fmt.Sprintf("localhost:%d", ts.Port()), WithCommands("Init1", "Init2"))
+	assert.Contains(t, err.Error(), "EOF")
+	assert.Nil(t, session, "Session should be nil")
+}
+
+func TestSessionSetupWithInitCommands(t *testing.T) {
+	dummySh, ts := dummyServer(t)
+	defer ts.Close()
+
+	sshConfig := validSSHConfig()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), sshConfig,
+		fmt.Sprintf("localhost:%d", ts.Port()), WithCommands("Init1", "Init2"))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+
+	assert.Equal(t, "Init1\n", dummySh.lines[0])
+	assert.Equal(t, "Init2\n", dummySh.lines[1])
+}
+
+func TestSessionSetupWithFailingInitCommands(t *testing.T) {
+	dummySh, ts := dummyServer(t)
+	defer ts.Close()
+
+	sshConfig := validSSHConfig()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), sshConfig,
+		fmt.Sprintf("localhost:%d", ts.Port()), WithCommands("Init1", "close", "Init2"))
+	assert.Contains(t, err.Error(), "EOF")
+	assert.Nil(t, session, "Session should be nil")
+
+	assert.Len(t, dummySh.lines, 2)
+	assert.Equal(t, "Init1\n", dummySh.lines[0])
+	assert.Equal(t, "close\n", dummySh.lines[1])
+}
+
+func TestSessionSetupWithTimeout(t *testing.T) {
+	_, ts := dummyServer(t)
+	defer ts.Close()
+
+	sshConfig := validSSHConfig()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), sshConfig,
+		fmt.Sprintf("localhost:%d", ts.Port()), WithTimeout(time.Millisecond*250))
+	assert.NoError(t, err)
+	assert.NotNil(t, session, "Session should not be nil")
+	defer session.Close()
+	assert.Equal(t, time.Millisecond*250, session.(*SessionImpl).cfg.readTimeout)
+}
+
+func TestSessionSetupInvalidOptions(t *testing.T) {
+	_, ts := dummyServer(t)
+	defer ts.Close()
+
+	sshConfig := validSSHConfig()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), sshConfig,
+		fmt.Sprintf("localhost:%d", ts.Port()), WithPrompt("BadRegex("))
+	assert.Contains(t, err.Error(), "invalid prompt pattern")
+	assert.Nil(t, session)
+}
+
+type dummyShell struct {
+	// Prompt that should be emitted.
+	prompt string
+	// Record of commands received.
+	lines []string
+	// Signals that shell should close immediately.
+	fail bool
+}
+
+const defaultPrompt = "ABC> "
+
+// Simple Handler implementation that echoes lines.
+func (e *dummyShell) Handle(t assert.TestingT, ch ssh.Channel) {
+	if e.fail {
+		_ = ch.Close()
+		return
+	}
+	chReader := bufio.NewReader(ch)
+	chWriter := bufio.NewWriter(ch)
+	prompt := e.prompt
+	if prompt == "" {
+		prompt = defaultPrompt
+	}
+	_, _ = chWriter.WriteString(prompt)
+	chWriter.Flush()
+	for {
+		input, err := chReader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		e.lines = append(e.lines, input)
+
+		switch input {
+		case "enable\n":
+			_, _ = chWriter.WriteString("\nPassword: ")
+			_ = chWriter.Flush()
+			prompt = "ABC# "
+		case "close\n":
+			_ = ch.Close()
+			return
+		default:
+			_, err = chWriter.WriteString(fmt.Sprintf("GOT:%s\n", input))
+			assert.NoError(t, err, "Write failed")
+			_, _ = chWriter.WriteString(prompt)
+			err = chWriter.Flush()
+			assert.NoError(t, err, "Flush failed")
+		}
+	}
+}
+
+func dummyServer(t *testing.T) (*dummyShell, *testserver.SSHServer) {
+	return dummyServerWithPrompt(t, "")
+}
+
+func dummyServerWithPrompt(t *testing.T, prompt string) (*dummyShell, *testserver.SSHServer) {
+	dummySh := &dummyShell{prompt: prompt}
+	ts := testserver.NewSSHServerHandler(t, testserver.TestUserName, testserver.TestPassword,
+		func(t assert.TestingT) testserver.SSHHandler {
+			return dummySh
+		},
+		testserver.RequestTypes([]string{"pty-req", "shell"}))
+	return dummySh, ts
+}
+
+func dummyServerWithFailingShell(t *testing.T) (*dummyShell, *testserver.SSHServer) {
+	dummySh := &dummyShell{fail: true}
+	ts := testserver.NewSSHServerHandler(t, testserver.TestUserName, testserver.TestPassword,
+		func(t assert.TestingT) testserver.SSHHandler {
+			return dummySh
+		},
+		testserver.RequestTypes([]string{"pty-req", "shell"}))
+	return dummySh, ts
+}
+
+//nolint: gocritic
+//Simple real NE access tests
+//
+//func TestRealNewSession(tport *testing.T) {
+//
+//	factory := NewSessionFactory(nil)
+//
+//	sshConfig := &ssh.ClientConfig{
+//		User:            "xxxxx",
+//		Auth:            []ssh.AuthMethod{ssh.Password(os.Getenv("PASS")},
+//		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+//		Config: ssh.Config{
+//			KeyExchanges: []string{"diffie-hellman-group1-sha1", "diffie-hellman-group14-sha1"},
+//			Ciphers:      []string{"aes128-cbc", "aes128-ctr"},
+//		},
+//	}
+//
+//	devs := []string{"9.9.9.9"}
+//	for _, d := range devs {
+//		session, err := factory.NewSession(context.Background(), sshConfig, d+":22", WithCommands([]string{"terminal length 0"}))
+//		assert.NoError(tport, err, "failed to create session")
+//		assert.NotNil(tport, session)
+//		defer session.Close()
+//
+//		b, err := session.Send("show running-config")
+//		assert.NoError(tport, err, "failed to send command")
+//
+//		fmt.Println("running config >" + b + "<")
+//	}
+//}
+//
+//func TestRealNewSession2(tport *testing.T) {
+//
+//	factory := NewSessionFactory(nil)
+//
+//	sshConfig := &ssh.ClientConfig{
+//		User:            "xxxxx",
+//		Auth:            []ssh.AuthMethod{ssh.Password(os.Getenv("XXXXX")},
+//		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+//	}
+//
+//	session, err := factory.NewSession(context.Background(), sshConfig, "9.9.9.9:22")
+//	assert.NoError(tport, err, "failed to create session")
+//	assert.NotNil(tport, session)
+//	defer session.Close()
+//
+//	b, err := session.Send("ls")
+//	assert.NoError(tport, err, "failed to send command")
+//
+//	fmt.Println("ls >" + b + "<")
+//}
+//
+//func TestRealNewSession3(tport *testing.T) {
+//
+//	factory := NewSessionFactory(nil)
+//
+//	sshConfig := &ssh.ClientConfig{
+//		User:            "xxxxx",
+//		Auth:            []ssh.AuthMethod{ssh.Password(os.Getenv("PASS")},
+//		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+//		Config: ssh.Config{
+//			KeyExchanges: []string{"diffie-hellman-group1-sha1"},
+//			Ciphers:      []string{"aes128-cbc"},
+//		},
+//	}
+//
+//	devs := []string{"9.9.9.9"}
+//	for _, d := range devs {
+//		session, err := factory.NewSession(context.Background(), sshConfig, d+":22", WithCommands([]string{"terminal length 0"}))
+//		assert.NoError(tport, err, "failed to create session")
+//		assert.NotNil(tport, session)
+//		defer session.Close()
+//		_, err = session.Send("enable", WaitFor("Password: "))
+//		assert.NoError(tport, err)
+//		_, err = session.Send("xxxxx", ResetPrompt())
+//		b, err := session.Send("show running-config")
+//		assert.NoError(tport, err, "failed to send command")
+//
+//		fmt.Println("running config >" + b + "<")
+//	}
+//}

--- a/v2/ssh_cli/transport.go
+++ b/v2/ssh_cli/transport.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"context"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/imdario/mergo"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type SSHTransport interface {
+	io.WriteCloser
+	io.Reader
+}
+
+type TransportConfig struct{}
+
+var DefaultTransportConfig = TransportConfig{}
+
+type transportImpl struct {
+	cfg     *TransportConfig
+	client  *ssh.Client
+	session *ssh.Session
+	io.Reader
+	io.WriteCloser
+}
+
+func NewSSHTransport(ctx context.Context, sshcfg *ssh.ClientConfig, cfg *TransportConfig, target string) (SSHTransport, error) {
+	// Use supplied config, but apply any defaults to unspecified values.
+	resolvedConfig := *cfg
+	_ = mergo.Merge(&resolvedConfig, DefaultTransportConfig)
+
+	var err error
+	t := &transportImpl{cfg: &resolvedConfig}
+	t.client, err = ssh.Dial("tcp", target, sshcfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "new Clisession failed")
+	}
+
+	t.session, err = t.client.NewSession()
+	if err != nil {
+		t.Close()
+		return nil, errors.Wrap(err, "new ssh session failed")
+	}
+
+	t.Reader, _ = t.session.StdoutPipe()
+	// TODO Handle stderr
+	// ereader, _ := session.StderrPipe()
+	t.WriteCloser, _ = t.session.StdinPipe()
+
+	terminalMode := ssh.TerminalModes{
+		ssh.ECHO: 0,
+		// ssh.TTY_OP_ISPEED: 28800,
+		// ssh.TTY_OP_OSPEED: 28800,
+	}
+	err = t.session.RequestPty("dumb", 80, 80, terminalMode)
+	if err != nil {
+		_ = t.Close()
+		return nil, errors.Wrap(err, "request pty failed")
+	}
+
+	if err = t.session.Shell(); err != nil {
+		_ = t.Close()
+		return nil, errors.Wrap(err, "login shell failed")
+	}
+
+	return t, nil
+}
+
+func (t *transportImpl) Close() error {
+	if t.WriteCloser != nil {
+		_ = t.WriteCloser.Close()
+	}
+	if t.session != nil {
+		_ = t.session.Close()
+	}
+	if t.client != nil {
+		_ = t.client.Close()
+	}
+	return nil
+}

--- a/v2/ssh_cli/transport_test.go
+++ b/v2/ssh_cli/transport_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/damianoneill/net/v2/netconf/testserver"
+
+	assert "github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestAuthenticationFailure(t *testing.T) {
+	ts := testserver.NewSSHServer(t, testserver.TestUserName, testserver.TestPassword)
+	defer ts.Close()
+
+	sshConfig := sshConfigWithPassword("WrongPassword")
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), sshConfig, fmt.Sprintf("localhost:%d", ts.Port()))
+
+	assert.Error(t, err, "Expecting new session to fail - invalid password")
+	assert.Nil(t, session, "Session should be nil")
+}
+
+func TestRequestPtyFailure(t *testing.T) {
+	ts := testserver.NewSSHServerHandler(t, testserver.TestUserName, testserver.TestPassword,
+		func(t assert.TestingT) testserver.SSHHandler {
+			return &dummyShell{}
+		},
+		testserver.RequestTypes([]string{}))
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(), fmt.Sprintf("localhost:%d", ts.Port()))
+	assert.Contains(t, err.Error(), "request pty failed")
+	assert.Nil(t, session)
+}
+
+func TestShellFailure(t *testing.T) {
+	ts := testserver.NewSSHServerHandler(t, testserver.TestUserName, testserver.TestPassword,
+		func(t assert.TestingT) testserver.SSHHandler {
+			return &dummyShell{}
+		},
+		testserver.RequestTypes([]string{"pty-req"}))
+	defer ts.Close()
+
+	factory := NewSessionFactory(nil)
+
+	session, err := factory.NewSession(context.Background(), validSSHConfig(), fmt.Sprintf("localhost:%d", ts.Port()))
+	assert.Contains(t, err.Error(), "login shell failed")
+	assert.Nil(t, session)
+}
+
+func validSSHConfig() *ssh.ClientConfig {
+	return sshConfigWithPassword(testserver.TestPassword)
+}
+
+func sshConfigWithPassword(pass string) *ssh.ClientConfig {
+	sshConfig := &ssh.ClientConfig{
+		User:            testserver.TestUserName,
+		Auth:            []ssh.AuthMethod{ssh.Password(pass)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint: gosec
+	}
+	return sshConfig
+}


### PR DESCRIPTION
Basic implementation with a Send method:
- Sends command to server
- Returns server response

Simple extension points allow customisation for different server OS types:
- Different strategies for determining the cli prompt that signals the end of the server response
- Optional execution of initial commands to configure the server shell

The server response is returned as a single string.
It is the caller's responsibility to parse this, depending on the expected structure.