### PR TITLE
Remove satori dependency from original netconf client 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.15
 require (
 	github.com/git-chglog/git-chglog v0.15.0
 	github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170
+	github.com/google/uuid v1.3.0
 	github.com/goreleaser/goreleaser v1.1.0
 	github.com/imdario/mergo v0.3.12
 	github.com/mcubik/goverreport v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/psampaz/go-mod-outdated v0.8.0
-	github.com/satori/go.uuid v1.2.0
 	github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989
 	github.com/segmentio/golines v0.6.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989 h1:rq2/kILQnPtq5oL4+IAjgVOjh5e2yj2aaCYi7squEvI=
 github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+yDFh9SZXUTvspXTjbFXgZGP/UvhU1S65A4A=

--- a/netconf/message.go
+++ b/netconf/message.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // The Message layer defines a set of base protocol operations
@@ -156,7 +156,7 @@ func (si *sesImpl) ExecuteAsync(req Request, rchan chan *RPCReply) (err error) {
 
 func (si *sesImpl) execute(req Request, rchan chan *RPCReply) (err error) {
 	// Build the request to be submitted.
-	msg := &RPCMessage{MessageID: uuid.NewV4().String(), Methods: []byte(string(req))}
+	msg := &RPCMessage{MessageID: uuid.New().String(), Methods: []byte(string(req))}
 
 	// Lock the request channel, so the request and response channel set up is atomic.
 	si.reqLock.Lock()


### PR DESCRIPTION
v2 still depends on github.com/damianoneill/net, so inherited that dependency.

Please tag when merged.