### PR TITLE
Change netconf session factory to expose new methods to …

### DIFF
--- a/v2/netconf/server/ssh/server_test.go
+++ b/v2/netconf/server/ssh/server_test.go
@@ -52,7 +52,8 @@ func TestServer(t *testing.T) {
 	}
 
 	ctx = context.Background()
-	tr, err := client.NewSSHTransport(ctx, sshConfig, fmt.Sprintf("localhost:%d", server.Port()), "netconf")
+	target := fmt.Sprintf("localhost:%d", server.Port())
+	tr, err := client.NewSSHTransport(ctx, client.NewDialer(target, sshConfig), target)
 	assert.NoError(t, err, "Not expecting new transport to fail")
 	defer tr.Close()
 
@@ -92,7 +93,8 @@ func TestServerConnectionFailure(t *testing.T) {
 	}
 
 	ctx = context.Background()
-	_, err = client.NewSSHTransport(ctx, sshConfig, fmt.Sprintf("localhost:%d", server.Port()), "netconf")
+	target := fmt.Sprintf("localhost:%d", server.Port())
+	_, err = client.NewSSHTransport(ctx, client.NewDialer(target, sshConfig), target)
 	assert.Error(t, err, "Not expecting new transport to succeed")
 	assert.Contains(t, err.Error(), "authenticate")
 }
@@ -116,7 +118,8 @@ func TestServerDiagnosticTraceHooks(t *testing.T) {
 	}
 
 	ctx = context.Background()
-	tr, err := client.NewSSHTransport(ctx, sshConfig, fmt.Sprintf("localhost:%d", server.Port()), "netconf")
+	target := fmt.Sprintf("localhost:%d", server.Port())
+	tr, err := client.NewSSHTransport(ctx, client.NewDialer(target, sshConfig), target)
 	assert.NoError(t, err, "Not expecting new transport to fail")
 	defer tr.Close()
 
@@ -145,7 +148,8 @@ func TestServerNoOpTraceHooks(t *testing.T) {
 	}
 
 	ctx = context.Background()
-	tr, err := client.NewSSHTransport(ctx, sshConfig, fmt.Sprintf("localhost:%d", server.Port()), "netconf")
+	target := fmt.Sprintf("localhost:%d", server.Port())
+	tr, err := client.NewSSHTransport(ctx, client.NewDialer(target, sshConfig), target)
 	assert.NoError(t, err, "Not expecting new transport to fail")
 	defer tr.Close()
 


### PR DESCRIPTION
…create client sessions from a pre-existing ssh client.

Internally, defines 'SSHClientFactory' abstraction with 2 implementations:
- original code, that calls ssh.Dial with caller-supplied config
- 'no-op' implementation that simply returns the caller-supplied pre-existing ssh client.
